### PR TITLE
Fix Scorecard action pin

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Pin Scorecard to the commit behind v2.4.3 instead of the annotated tag object SHA.
- Unblocks Scorecard result publishing workflow verification.

## Verification
- npm test
- git ls-remote confirmed refs/tags/v2.4.3^{} resolves to 4eaacf0543bb3f2c246792bd56e8cdeffafb205a