### PR TITLE
Remove workflow npm self-installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
           node-version: "22.14.0"
           cache: npm
 
-      - name: Use npm 11.5.1 or newer
-        run: npm install -g npm@11.5.1
-
       - name: Install dependencies
         run: npm ci
 
@@ -58,9 +55,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-
-      - name: Use npm 11.5.1 or newer
-        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,9 +33,6 @@ jobs:
           node-version: "22.14.0"
           registry-url: https://registry.npmjs.org
 
-      - name: Use npm 11.5.1 or newer
-        run: npm install -g npm@11.5.1
-
       - name: Show publishing toolchain
         run: |
           node --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,6 @@ jobs:
           node-version: "22.14.0"
           cache: npm
 
-      - name: Use npm 11.5.1 or newer
-        run: npm install -g npm@11.5.1
-
       - name: Validate release tag
         run: node scripts/validate-release.mjs "$GITHUB_REF_NAME"
 


### PR DESCRIPTION
## Summary
- remove global npm self-install steps from CI, release, and publish workflows
- rely on pinned setup-node runtimes instead of mutable npm install commands

## Validation
- npm test
- npm run shrinkwrap:check
- git diff --check