### PR TITLE
Fix SAST workflow coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,8 @@ name: CodeQL
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
+  workflow_dispatch:
   schedule:
     - cron: "37 3 * * 1"
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -2,11 +2,16 @@ name: Scorecards
 
 on:
   branch_protection_rule:
-  schedule:
-    - cron: "31 3 * * 1"
-  push:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CodeQL
+    types:
+      - completed
     branches:
       - master
+  schedule:
+    - cron: "31 3 * * 1"
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
- Run CodeQL on all push and pull_request events so Scorecard sees SAST on branch commits.
- Trigger Scorecards after CodeQL completes on master to avoid racing SARIF uploads.

## Testing
- npm test
- git diff --check