### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-28
+
 ### Added
 
+- ST-Link debugger backend through STM32CubeProgrammer CLI with safe probe, flash, reset, report, and error-classification behavior.
 - Dependency Review and OSSF Scorecard workflows for pull-request and repository hardening signals.
 - `npm-shrinkwrap.json` as the authoritative publishable lockfile for the CLI dependency tree.
 - Release SBOM generation and artifact attestations for GitHub Release tarballs.
@@ -16,6 +19,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 
 - Node.js support is now explicit for Node.js 22.14 through 24, with CI covering both supported runtime lines on Linux, macOS, and Windows.
+- CodeQL and Scorecards workflows now cover branch and pull-request commits without racing SAST result uploads.
 - Release and contributor documentation now describe SBOMs, attestations, npm provenance, and branch-protection expectations.
 
 ## [0.1.1] - 2026-06-26

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "aihil",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aihil",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aihil",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Generic hardware-in-the-loop debugger interface for AI agents",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
## Summary
- Bump package metadata and shrinkwrap to 0.2.0.
- Move the ST-Link backend and SAST workflow coverage changes into the 0.2.0 changelog.

## Testing
- npm test
- npm run shrinkwrap:check
- npm run audit:prod
- npm run pack:check
- node scripts/validate-release.mjs v0.2.0