### PR TITLE
Fix npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,6 +33,9 @@ jobs:
           node-version: "22.14.0"
           registry-url: https://registry.npmjs.org
 
+      - name: Install trusted publishing npm
+        run: npm install --global npm@11.5.1
+
       - name: Show publishing toolchain
         run: |
           node --version


### PR DESCRIPTION
## Summary
- Install pinned npm 11.5.1 in the npm publish workflow before publishing.
- Keep the publish workflow aligned with the packageManager metadata required for trusted publishing.

## Testing
- git diff --check
- Failed publish run diagnosed: https://github.com/hp-8472/aihil/actions/runs/28304744286