### PR TITLE
Relax Node runtime engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22.14.0"
+          node-version: "24.x"
           cache: npm
 
       - name: Install dependencies
@@ -43,7 +43,8 @@ jobs:
           - macos-latest
           - windows-latest
         node-version:
-          - "22.14.0"
+          - "16.16.0"
+          - "22.x"
           - "24.x"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,15 @@ name: Node CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -68,3 +76,25 @@ jobs:
 
       - name: Check package contents
         run: npm run pack:check
+
+  required-ci:
+    name: Required CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - audit
+      - test
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          if [[ "${{ needs.audit.result }}" != "success" ]]; then
+            echo "Production dependency audit finished with ${{ needs.audit.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "Node test matrix finished with ${{ needs.test.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.x"
+          node-version: "lts/*"
           cache: npm
 
       - name: Install dependencies
@@ -54,6 +54,7 @@ jobs:
           - "16.16.0"
           - "22.x"
           - "24.x"
+          - "lts/*"
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,18 @@ name: CodeQL
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
   schedule:
     - cron: "37 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22.14.0"
+          node-version: "24.x"
           registry-url: https://registry.npmjs.org
 
       - name: Install trusted publishing npm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.x"
+          node-version: "lts/*"
           registry-url: https://registry.npmjs.org
 
       - name: Install trusted publishing npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22.14.0"
+          node-version: "24.x"
           cache: npm
 
       - name: Validate release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.x"
+          node-version: "lts/*"
           cache: npm
 
       - name: Validate release tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Use this as the reference setup unless project files or the user clearly specify
 - Board: STM32 Nucleo-F446RE.
 - Debug probe: ST-Link, including the onboard Nucleo ST-Link.
 - Debug backend: OpenOCD.
-- Host runtime: Node.js 22.14 or newer LTS with npm.
+- Host runtime: Node.js 16.16 or newer with npm; current Node.js LTS is recommended.
 - OpenOCD interface config: `interface/stlink.cfg`.
 - OpenOCD target config: `target/stm32f4x.cfg`.
 - Firmware artifact root: `build/`.
@@ -28,6 +28,10 @@ Install the `aihil` command once on the local machine from npm with:
 ```bash
 npm i -g aihil
 ```
+
+If Node.js is missing or too old for AI-HIL's `engines`, do not refuse or stop at the error. Treat it as a host setup prerequisite: install or activate a supported Node.js/npm runtime, then rerun the AI-HIL install. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless the operator asks for that version; any runtime accepted by `package.json` is fine. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If no safe local installer is apparent, ask one concise question about how the operator wants Node.js installed.
+
+Do not work around an old runtime with `--force`, `--ignore-engines`, or an older AI-HIL version. The correct fix is a supported Node.js/npm runtime.
 
 From this repository checkout, install with:
 

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -11,7 +11,7 @@ Prefer the supported first path unless the firmware project or user clearly says
 - STM32 Nucleo-F446RE.
 - ST-Link.
 - OpenOCD.
-- Node.js 22.14 or newer LTS with npm.
+- Node.js 16.16 or newer with npm; current Node.js LTS is recommended.
 - `interface/stlink.cfg`.
 - `target/stm32f4x.cfg`.
 - Firmware artifacts under `build/`.
@@ -25,6 +25,10 @@ Install the `aihil` command once on the local machine from npm with:
 ```bash
 npm i -g aihil
 ```
+
+If the host has no Node.js or an old Node.js, keep going by installing or activating a supported Node.js/npm runtime, then rerun `npm i -g aihil`. Current Node.js LTS is fine, but the agent does not need to pin a specific Node.js patch version; any runtime accepted by `package.json` is fine. An outdated Node.js is a remediable setup prerequisite, not a reason to refuse the AI-HIL setup. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If the safe local install path is unclear, ask one concise question.
+
+Do not use `--force`, `--ignore-engines`, or an older AI-HIL version to bypass the Node.js requirement.
 
 From this repository checkout, install with:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- Relaxed the AI-HIL runtime engine from Node.js 22.14+ to Node.js 16.16+ while keeping current Node.js LTS recommended.
+
 ## [0.2.0] - 2026-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 
 - Relaxed the AI-HIL runtime engine from Node.js 22.14+ to Node.js 16.16+ while keeping current Node.js LTS recommended.
+- Added explicit CI coverage for the current Node.js LTS alias so industrial deployment environments remain visible in release checks.
 
 ## [0.2.0] - 2026-06-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Canonical agent instructions live in `AGENTS.md` and `AI_AGENT_QUICKSTART.md`. H
 
 AI-HIL is a TypeScript/Node.js MCP stdio server for safe embedded hardware-in-the-loop access. It exposes narrow tools for probing, flashing, resetting, configured COM port stimulus/feedback, and reading structured reports from a configured local target.
 
-Use STM32 Nucleo-F446RE + ST-Link + OpenOCD + Node.js 22.14 or newer LTS as the supported first path unless project files or the user clearly identify another setup.
+Use STM32 Nucleo-F446RE + ST-Link + OpenOCD + Node.js 16.16 or newer with npm as the supported first path unless project files or the user clearly identify another setup. Current Node.js LTS is recommended.
 
 ## Installation Model
 
@@ -17,6 +17,10 @@ Install the `aihil` command once on the local machine from npm with:
 ```bash
 npm i -g aihil
 ```
+
+If Node.js is missing or too old for AI-HIL's `engines`, do not refuse or stop at the error. Install or activate a supported Node.js/npm runtime, then rerun the AI-HIL install. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless the operator asks for that version; any runtime accepted by `package.json` is fine. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If no safe local installer is apparent, ask one concise question about how the operator wants Node.js installed.
+
+Do not work around an old runtime with `--force`, `--ignore-engines`, or an older AI-HIL version. The correct fix is a supported Node.js/npm runtime.
 
 From this repository checkout, install with:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It turns firmware work into a hardware-in-the-loop cycle: edit, build, probe, fl
 ## Trust & Supply Chain
 
 - Public source, Apache-2.0 license, security policy, issue templates, PR template, and CODEOWNERS are part of the repository.
-- CI tests Node.js 22.14 and 24 with npm 11.5.1+ on Linux, macOS, and Windows; CodeQL scans JavaScript and TypeScript.
+- CI tests Node.js 16.16, 22, and 24 on Linux, macOS, and Windows; CodeQL scans JavaScript and TypeScript.
 - Dependabot and Dependency Review watch npm and GitHub Actions dependency changes.
 - npm releases use GitHub Actions trusted publishing with OIDC and provenance.
 - The published CLI uses `npm-shrinkwrap.json` to freeze the dependency tree installed by npm.
@@ -41,7 +41,7 @@ aihil doctor
 aihil mcp-config > .mcp.json
 ```
 
-Use this path when adding AI-HIL to an existing firmware project. Each project gets its own `.aihil/config.yaml` for target, debugger, artifact roots, permissions, reports, logs, and optional COM ports. If setup fails, start with [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+Use this path when adding AI-HIL to an existing firmware project. AI-HIL requires Node.js 16.16 or newer with npm; current Node.js LTS is recommended. If `npm i -g aihil` reports an old Node.js or `engines` error, install or activate a supported runtime first and rerun the install. Do not bypass the requirement with `--force`, `--ignore-engines`, or an older AI-HIL version. Each project gets its own `.aihil/config.yaml` for target, debugger, artifact roots, permissions, reports, logs, and optional COM ports. If setup fails, start with [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ### Run the supported Nucleo demo
 
@@ -159,7 +159,7 @@ The official reference setup is deliberately narrow:
 - Board: STM32 Nucleo-F446RE.
 - Debug probe: ST-Link, including the onboard Nucleo ST-Link.
 - Debug backend: OpenOCD.
-- Host runtime: Node.js 22.14 or newer LTS with npm; CI covers Node.js 22 and 24.
+- Host runtime: Node.js 16.16 or newer with npm; current Node.js LTS is recommended, and CI covers Node.js 16.16, 22, and 24.
 - OpenOCD interface config: `interface/stlink.cfg`.
 - OpenOCD target config: `target/stm32f4x.cfg`.
 - Firmware artifact root: `build/`.
@@ -190,6 +190,8 @@ Install the `aihil` command once on the local machine:
 ```bash
 npm i -g aihil
 ```
+
+If the host has no Node.js or an old Node.js, install or activate a supported Node.js/npm runtime, then rerun the AI-HIL install. Current Node.js LTS is fine, but you do not need to install a specific Node.js patch version; any runtime accepted by `package.json` is fine. On Windows, `winget install OpenJS.NodeJS.LTS` is the usual direct path when `winget` is available. On macOS or Linux, use the local team's preferred version manager or package manager. Do not use `--force`, `--ignore-engines`, or older AI-HIL versions to bypass the runtime requirement.
 
 From this repository checkout, install the local version with:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It turns firmware work into a hardware-in-the-loop cycle: edit, build, probe, fl
 ## Trust & Supply Chain
 
 - Public source, Apache-2.0 license, security policy, issue templates, PR template, and CODEOWNERS are part of the repository.
-- CI tests Node.js 16.16, 22, and 24 on Linux, macOS, and Windows; CodeQL scans JavaScript and TypeScript.
+- CI tests Node.js 16.16, 22, 24, and the current LTS alias on Linux, macOS, and Windows; CodeQL scans JavaScript and TypeScript.
 - Dependabot and Dependency Review watch npm and GitHub Actions dependency changes.
 - npm releases use GitHub Actions trusted publishing with OIDC and provenance.
 - The published CLI uses `npm-shrinkwrap.json` to freeze the dependency tree installed by npm.
@@ -159,7 +159,7 @@ The official reference setup is deliberately narrow:
 - Board: STM32 Nucleo-F446RE.
 - Debug probe: ST-Link, including the onboard Nucleo ST-Link.
 - Debug backend: OpenOCD.
-- Host runtime: Node.js 16.16 or newer with npm; current Node.js LTS is recommended, and CI covers Node.js 16.16, 22, and 24.
+- Host runtime: Node.js 16.16 or newer with npm; current Node.js LTS is recommended, and CI covers Node.js 16.16, 22, 24, and the current LTS alias.
 - OpenOCD interface config: `interface/stlink.cfg`.
 - OpenOCD target config: `target/stm32f4x.cfg`.
 - Firmware artifact root: `build/`.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-This page covers the most common AI-HIL setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Node.js 22.14 or newer LTS.
+This page covers the most common AI-HIL setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Node.js 16.16 or newer with npm. Current Node.js LTS is recommended.
 
 Always inspect structured JSON first. The most useful fields are `ok`, `error_type`, `backend_error_type`, `summary`, `likely_causes`, `report_path`, and `log_path`.
 
@@ -24,6 +24,8 @@ Fix:
 npm i -g aihil
 aihil doctor
 ```
+
+If npm reports an old Node.js version or an `engines` error, install or activate a supported Node.js/npm runtime, open a fresh shell if needed, and rerun `npm i -g aihil`. Current Node.js LTS is fine, but you do not need to install a specific Node.js patch version; any runtime accepted by `package.json` is fine. On Windows, `winget install OpenJS.NodeJS.LTS` is the usual direct path when `winget` is available. Do not use `--force`, `--ignore-engines`, or an older AI-HIL version to bypass the runtime requirement.
 
 If developing from this checkout, run:
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,8 @@ Install the `aihil` command and MCP server once on the local machine:
 npm i -g aihil
 ```
 
+AI-HIL requires Node.js 16.16 or newer with npm; current Node.js LTS is recommended. If Node.js is missing or outdated, install or activate a supported runtime first, then rerun the AI-HIL install. Do not pin a specific Node.js patch version unless asked; any runtime accepted by `package.json` is fine. Do not bypass `engines` with `--force`, `--ignore-engines`, or an older AI-HIL version.
+
 From a repository checkout, use `npm install --global .`.
 
 Each firmware project should contain its own `.aihil/` directory with `.aihil/config.yaml` for that project's target, debugger, permissions, reports, logs, and artifact roots.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22.14 <25"
+        "node": ">=16.16"
       }
     },
     "node_modules/@serialport/binding-mock": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "provenance": true
   },
   "engines": {
-    "node": ">=22.14 <25"
+    "node": ">=16.16"
   },
   "files": [
     "dist",

--- a/skills/aihil-config-setup/SKILL.md
+++ b/skills/aihil-config-setup/SKILL.md
@@ -17,9 +17,11 @@ The schema bundled with the installed `aihil` Node.js package is authoritative. 
 
 ## Supported First Path
 
-Use STM32 Nucleo-F446RE, ST-Link, OpenOCD, Node.js 22.14 or newer LTS, `interface/stlink.cfg`, `target/stm32f4x.cfg`, and firmware artifacts under `build/` as the reference setup unless project files or the user clearly specify a different target.
+Use STM32 Nucleo-F446RE, ST-Link, OpenOCD, Node.js 16.16 or newer with npm, `interface/stlink.cfg`, `target/stm32f4x.cfg`, and firmware artifacts under `build/` as the reference setup unless project files or the user clearly specify a different target. Current Node.js LTS is recommended.
 
 If the board, MCU family, debugger interface, target config, COM port, or artifact root cannot be inferred from project files, ask one concise question instead of guessing.
+
+If `aihil` is not installed because Node.js is missing or too old, install or activate a supported Node.js/npm runtime before running `aihil init`. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless asked; any runtime accepted by `package.json` is fine. Do not refuse the setup for an old Node.js runtime, and do not bypass `engines` with `--force`, `--ignore-engines`, or an older AI-HIL version.
 
 ## Safety Boundaries
 


### PR DESCRIPTION
Summary:
- Lower Node runtime engine to >=16.16 and update shrinkwrap.
- Add CI coverage for Node 16.16, 22, and 24 while release/publish uses Node 24.
- Update install guidance so agents remediate old Node instead of refusing.

Tests:
- npm ci --ignore-scripts
- npm run shrinkwrap:check
- npm test