### PR TITLE
Document agent skill setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ AI-HIL is a local MCP stdio server that gives AI agents safe, structured access 
 
 Use the MCP server from this repository for hardware actions. Do not use raw OpenOCD commands or arbitrary shell commands for flashing, probing, or resetting hardware when an AI-HIL MCP tool is available.
 
-This file is for AI agents. Humans should start with `README.md` and `TROUBLESHOOTING.md`; agents should use this file and `AI_AGENT_QUICKSTART.md`. When working from this source checkout, the optional repository-local skill lives at `skills/aihil-config-setup/SKILL.md`.
+This file is for AI agents. Humans should start with `README.md` and `TROUBLESHOOTING.md`; agents should use this file, `AI_AGENT_QUICKSTART.md`, and `skills/aihil-config-setup/SKILL.md`.
 
 ## Supported First Path
 
@@ -38,7 +38,22 @@ npm i -g aihil
 npm i -g github:hp-8472/aihil
 ```
 
-Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills.
+Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills. When an AI agent is asked to install AI-HIL, the agent must install the skills separately as an agent setup step.
+
+## Agent Skill Installation
+
+Agent-driven AI-HIL installation includes skill installation. Do this after the `aihil` command is installed and before setting up the firmware project.
+
+Use `skills/aihil-config-setup/SKILL.md` from this repository as the source. If this source checkout is not available, clone or fetch the AI-HIL repository outside the firmware project only for the skill source, then remove that temporary checkout if it is no longer needed.
+
+Install the skill into the active agent's user-level skill directory. Known locations:
+
+- opencode: `$HOME/.config/opencode/skills/aihil-config-setup/SKILL.md`.
+- Claude Code: `$HOME/.claude/skills/aihil-config-setup/SKILL.md`.
+
+For other skill-capable agents, use that agent's documented user-level skill directory. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
+
+Do not rely on npm for skills, and do not add npm `postinstall` hooks for skill installation. Skill installation is an agent workflow responsibility, not package-manager behavior.
 
 If Node.js is missing or too old for AI-HIL's `engines`, do not refuse or stop at the error. Treat it as a host setup prerequisite: install or activate a supported Node.js/npm runtime, then rerun the AI-HIL install. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless the operator asks for that version; any runtime accepted by `package.json` is fine. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If no safe local installer is apparent, ask one concise question about how the operator wants Node.js installed.
 
@@ -60,9 +75,9 @@ npm test
 
 Each firmware project should have its own `.aihil/` directory with `.aihil/config.yaml` for that project's target, debugger, permissions, reports, logs, and artifact roots.
 
-`skills/aihil-config-setup/SKILL.md` is a repository-local agent asset, not an npm-installed file. Use it only when this repository checkout is available. Do not copy it into an agent's global skill directory unless the user explicitly asks for that.
+Use `skills/aihil-config-setup/SKILL.md` as the agent-facing workflow for creating or fixing `.aihil/config.yaml`. If the user asked the agent to install AI-HIL, this skill must already have been installed into the active agent's skill directory by the agent setup step above.
 
-If a user says "Install this AI-HIL repo and set it up for this project", install the `aihil` command from the AI-HIL repo, then return to the firmware project and follow this file and `AI_AGENT_QUICKSTART.md`. Do not expect a skill to be installed, and do not copy the AI-HIL source tree into the firmware project unless the user explicitly asks.
+If a user says "Install this AI-HIL repo and set it up for this project", install the `aihil` command, install the AI-HIL skills into the active agent's skill directory, then return to the firmware project and follow `skills/aihil-config-setup/SKILL.md`. Do not copy the AI-HIL source tree into the firmware project unless the user explicitly asks.
 
 ## Project Bootstrap
 

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -23,23 +23,38 @@ If the board, debugger, COM port, or artifact path cannot be inferred, ask one c
 Fast path:
 
 1. If `aihil --version` works, do not reinstall. On Windows, also try `aihil.cmd --version`.
-2. If AI-HIL is missing, install the `aihil` command once on the local machine from npm:
+2. If AI-HIL is missing, first try installing the `aihil` command once on the local machine from npm:
 
 ```bash
 npm i -g aihil
 ```
 
-3. If the user explicitly asked for the GitHub repo version, or the npm registry package rejects a Node.js version accepted by this repository, install directly from GitHub:
+3. If that npm registry install fails after Node.js/npm are available and accepted by this repository, install directly from GitHub:
 
 ```bash
 npm i -g github:hp-8472/aihil
 ```
 
-Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills.
+Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills. When an AI agent is asked to install AI-HIL, the agent must install the skills separately as an agent setup step.
 
 If the host has no Node.js or an old Node.js, keep going by installing or activating a supported Node.js/npm runtime, then rerun `npm i -g aihil`. Current Node.js LTS is fine, but the agent does not need to pin a specific Node.js patch version; any runtime accepted by `package.json` is fine. An outdated Node.js is a remediable setup prerequisite, not a reason to refuse the AI-HIL setup. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If the safe local install path is unclear, ask one concise question.
 
 Do not use `--force`, `--ignore-engines`, or an older AI-HIL version to bypass the Node.js requirement.
+
+## Install Agent Skill
+
+Agent-driven AI-HIL installation includes installing `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed.
+
+If this source checkout is not available, clone or fetch the AI-HIL repository outside the firmware project only for the skill source, then remove that temporary checkout if it is no longer needed.
+
+Known user-level skill destinations:
+
+- opencode: `$HOME/.config/opencode/skills/aihil-config-setup/SKILL.md`.
+- Claude Code: `$HOME/.claude/skills/aihil-config-setup/SKILL.md`.
+
+For other skill-capable agents, use that agent's documented user-level skill directory. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
+
+Do not rely on npm for skills, and do not add npm `postinstall` hooks for skill installation. Skill installation is an agent workflow responsibility, not package-manager behavior.
 
 From this repository checkout for AI-HIL development, install dependencies first and then link the checkout globally:
 
@@ -55,7 +70,7 @@ npm install
 npm test
 ```
 
-If you were given only the AI-HIL repository URL and asked to set up the current firmware project, install AI-HIL with the fast path above, then return to the firmware project. Do not expect a skill to be installed, and do not vendor the AI-HIL source tree into the firmware project.
+If you were given only the AI-HIL repository URL and asked to set up the current firmware project, install AI-HIL with the fast path above, install the AI-HIL skill into the active agent's skill directory, then return to the firmware project. Do not vendor the AI-HIL source tree into the firmware project.
 
 ## Configure Each Project
 
@@ -67,7 +82,7 @@ aihil init
 
 Edit `.aihil/config.yaml` for the local board, OpenOCD interface, target config, allowed firmware artifact roots, and any named COM ports.
 
-Agents should follow this workflow: use `aihil init`, edit only project-specific fields, keep safety policy restrictive, then validate with `aihil doctor`. If this source checkout is available, the optional repository-local `skills/aihil-config-setup/SKILL.md` contains the same setup workflow in skill form.
+Agents should follow `skills/aihil-config-setup/SKILL.md` for the exact setup workflow: use `aihil init`, edit only project-specific fields, keep safety policy restrictive, then validate with `aihil doctor`.
 
 Keep `.aihil/` with the project because it defines that project's hardware policy, reports, logs, and allowed artifact locations. Do not reinstall the MCP server inside every project.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,23 +15,38 @@ Use STM32 Nucleo-F446RE + ST-Link + OpenOCD + Node.js 16.16 or newer with npm as
 Fast path:
 
 1. If `aihil --version` works, do not reinstall. On Windows, also try `aihil.cmd --version`.
-2. If AI-HIL is missing, install the `aihil` command once on the local machine from npm:
+2. If AI-HIL is missing, first try installing the `aihil` command once on the local machine from npm:
 
 ```bash
 npm i -g aihil
 ```
 
-3. If the user explicitly asks for the GitHub repo version, or the npm registry package rejects a Node.js version accepted by this repository, install directly from GitHub without keeping a checkout in the firmware project:
+3. If that npm registry install fails after Node.js/npm are available and accepted by this repository, install directly from GitHub without keeping a checkout in the firmware project:
 
 ```bash
 npm i -g github:hp-8472/aihil
 ```
 
-Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills.
+Installing from npm or GitHub installs only the `aihil` CLI/MCP server. It does not install, register, or update agent skills. When an AI agent is asked to install AI-HIL, the agent must install the skills separately as an agent setup step.
 
 If Node.js is missing or too old for AI-HIL's `engines`, do not refuse or stop at the error. Install or activate a supported Node.js/npm runtime, then rerun the AI-HIL install. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless the operator asks for that version; any runtime accepted by `package.json` is fine. Prefer an existing version manager such as `nvm`, `fnm`, Volta, or `asdf`, or the local platform package manager such as `winget install OpenJS.NodeJS.LTS` on Windows or `brew install node` on macOS. If no safe local installer is apparent, ask one concise question about how the operator wants Node.js installed.
 
 Do not work around an old runtime with `--force`, `--ignore-engines`, or an older AI-HIL version. The correct fix is a supported Node.js/npm runtime.
+
+## Agent Skill Installation
+
+Agent-driven AI-HIL installation includes installing `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed.
+
+If this source checkout is not available, clone or fetch the AI-HIL repository outside the firmware project only for the skill source, then remove that temporary checkout if it is no longer needed.
+
+Known user-level skill destinations:
+
+- opencode: `$HOME/.config/opencode/skills/aihil-config-setup/SKILL.md`.
+- Claude Code: `$HOME/.claude/skills/aihil-config-setup/SKILL.md`.
+
+For other skill-capable agents, use that agent's documented user-level skill directory. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
+
+Do not rely on npm for skills, and do not add npm `postinstall` hooks for skill installation. Skill installation is an agent workflow responsibility, not package-manager behavior.
 
 From this repository checkout for AI-HIL development, install dependencies first and then link the checkout globally:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Report bugs and request enhancements through [GitHub Issues](https://github.com/
 
 ## Quick Start
 
-### Install from npm for a firmware project
+### Human CLI/MCP setup
 
 ```bash
 npm i -g aihil
@@ -43,13 +43,13 @@ aihil mcp-config > .mcp.json
 
 Use this path when adding AI-HIL to an existing firmware project. AI-HIL requires Node.js 16.16 or newer with npm; current Node.js LTS is recommended. If `npm i -g aihil` reports an old Node.js or `engines` error, install or activate a supported runtime first and rerun the install. Do not bypass the requirement with `--force`, `--ignore-engines`, or an older AI-HIL version. Each project gets its own `.aihil/config.yaml` for target, debugger, artifact roots, permissions, reports, logs, and optional COM ports. If setup fails, start with [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
-If you explicitly need the current GitHub repository version instead of the latest npm release, install it directly without cloning into the firmware project:
+If the npm registry install fails after Node.js/npm are available and accepted by this repository, install directly from GitHub without cloning into the firmware project:
 
 ```bash
 npm i -g github:hp-8472/aihil
 ```
 
-The npm and GitHub npm install paths install only the `aihil` CLI/MCP server. They do not install, register, or update agent skills.
+The npm and GitHub npm install paths install only the `aihil` CLI/MCP server. They do not install, register, or update agent skills. LLM/AI-agent setup instructions live in [`AGENTS.md`](AGENTS.md).
 
 ### Run the supported Nucleo demo
 
@@ -99,15 +99,11 @@ aihil doctor
 aihil mcp-config > .mcp.json
 ```
 
-Run `cmake --preset Debug` and then `cmake --build --preset Debug` before asking an agent to flash `build/Debug/nucleo-f446re_demo.elf`.
+Run `cmake --preset Debug` and then `cmake --build --preset Debug` before flashing `build/Debug/nucleo-f446re_demo.elf`.
 
 If OpenOCD is not on `PATH` or serial feedback is needed, edit the local `.aihil/config.yaml` before running `aihil doctor`. Do not commit machine-specific `.aihil/` files from the demo project.
 
-Open Claude Code, opencode, Codex, or another MCP-capable coding agent in `examples/nucleo-f446re_demo` and ask:
-
-```text
-Use AI-HIL to probe the target, flash build/Debug/nucleo-f446re_demo.elf, reset it in run mode, read the last report, and read the configured COM port if one is available.
-```
+For agent-driven flashing, open the project in your MCP-capable coding agent and use the agent-facing instructions in `AGENTS.md`.
 
 Expected firmware-in-the-loop path:
 
@@ -152,15 +148,12 @@ AI agents can edit firmware quickly, but embedded development only speeds up whe
 
 This README is for human developers and hardware operators.
 
-Agent-facing instructions in this source repository live in:
+Human-facing docs:
 
-- [`AGENTS.md`](AGENTS.md)
-- [`AI_AGENT_QUICKSTART.md`](AI_AGENT_QUICKSTART.md)
-- [`skills/aihil-config-setup/SKILL.md`](skills/aihil-config-setup/SKILL.md)
+- `README.md`: overview, human setup, expected outputs, and operator guidance.
+- `TROUBLESHOOTING.md`: diagnostics for setup and hardware failures.
 
-The skill file is a repository-local agent asset. It is not installed by the npm package.
-
-Troubleshooting lives in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+LLM/AI-agent instructions start in [`AGENTS.md`](AGENTS.md). Agent setup details are intentionally not duplicated in this README.
 
 ## Supported First Path
 
@@ -530,16 +523,6 @@ The default model is:
 |-- tests-ts/
 `-- package.json
 ```
-
-## Agent Entry Point
-
-If you want an AI coding agent to set up a firmware project with AI-HIL, open the firmware project and say:
-
-```text
-Install https://github.com/hp-8472/aihil and use it for this firmware project.
-```
-
-The agent should install the `aihil` CLI/MCP server, return to the firmware project, and follow `AGENTS.md` and `AI_AGENT_QUICKSTART.md`. Installing `aihil` does not install an agent skill; the repository-local `skills/aihil-config-setup/SKILL.md` is available only from a source checkout. The agent should not vendor the AI-HIL source tree into the firmware project unless you explicitly ask for that.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "docs/demo/README.md",
     "AGENTS.md",
     "AI_AGENT_QUICKSTART.md",
-    "skills/aihil-config-setup/SKILL.md",
     "LICENSE"
   ],
   "dependencies": {


### PR DESCRIPTION
## Summary

* Require agent-driven AI-HIL installs to copy the setup skill after installing the CLI.
* Keep README focused on human/operator setup while pointing LLM users to AGENTS.md.
* Exclude the skill file from npm package contents so npm remains CLI/MCP-only.

## Verification

* npm test
* npm run pack:check