### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-28
+
 ### Changed
 
 - Relaxed the AI-HIL runtime engine from Node.js 22.14+ to Node.js 16.16+ while keeping current Node.js LTS recommended.
 - Added explicit CI coverage for the current Node.js LTS alias so industrial deployment environments remain visible in release checks.
 - Made `aihil mcp-config` emit a Node entrypoint launch instead of relying on the `aihil` command name, avoiding Windows PATH collisions with unrelated executables.
-- Clarified the agent install fast path and GitHub direct install fallback in setup documentation.
+- Clarified the agent install fast path, GitHub direct install fallback, and mandatory agent-side skill installation in setup documentation.
+- Kept human setup guidance in `README.md` while moving LLM-specific installation responsibilities to `AGENTS.md`.
+- Removed the AI-HIL setup skill from npm package contents so the package remains CLI/MCP-only and agent skills remain separate agent configuration.
 
 ### Added
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "aihil",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aihil",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aihil",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Generic hardware-in-the-loop debugger interface for AI agents",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
## Summary

* Bump package metadata and shrinkwrap to 0.2.1.
* Move setup and agent-install changes into the 0.2.1 changelog.

## Testing

* npm test
* npm run shrinkwrap:check
* npm run audit:prod
* npm run pack:check
* node scripts/validate-release.mjs v0.2.1
* git diff --check