### PR TITLE
Add portable MCP template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ follow this model:
 3. Return to the firmware project.
 4. Create or update the project-local `.aihil/config.yaml`.
 5. Validate with `aihil doctor`.
-6. Generate project-local MCP config with `aihil mcp-config > .mcp.json`.
+6. Add the standard portable `.mcp.json` only if the MCP client needs project discovery.
 7. Use AI-HIL MCP tools for hardware actions.
 8. Do not copy or vendor the AI-HIL source tree into the firmware project unless the user explicitly asks for that.
 
@@ -104,7 +104,6 @@ Run setup from the firmware project directory, not from the AI-HIL source reposi
 ```bash
 aihil init
 aihil doctor
-aihil mcp-config > .mcp.json
 ```
 
 Each firmware project owns its own `.aihil/` directory. That directory contains:
@@ -164,15 +163,9 @@ permissions:
 
 ## MCP operating model
 
-AI-HIL uses MCP over stdio.
+AI-HIL uses MCP over stdio. The project-local MCP client config is only a launch entry; it should normally be the stable portable `.mcp.json` shape below.
 
-The project-local MCP client config is generated with:
-
-```bash
-aihil mcp-config > .mcp.json
-```
-
-The generated MCP server entry starts AI-HIL like this:
+The MCP server entry starts AI-HIL like this:
 
 ```text
 aihil mcp-stdio --config .aihil/config.yaml
@@ -355,7 +348,6 @@ Useful CLI commands:
 aihil init
 aihil doctor
 aihil com-ports
-aihil mcp-config
 aihil mcp-stdio --config .aihil/config.yaml
 aihil com-stdio --config .aihil/config.yaml --port dut_uart
 ```

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -96,7 +96,7 @@ Expected healthy result: `ok: true`, `tool: "aihil_doctor"`, `summary: "AI-HIL c
 
 ## Configure MCP
 
-AI-HIL uses MCP over stdio. The generated `.mcp.json` starts the installed Node entrypoint directly; this is equivalent to `aihil mcp-stdio` and avoids local `PATH` collisions.
+AI-HIL uses MCP over stdio. `.mcp.json` is only the MCP launch entry and should normally be the stable portable shape below.
 
 `mcp-stdio` does not take `--port`; it is project-scoped. COM MCP tool calls pass `port_id` as tool arguments.
 
@@ -106,11 +106,18 @@ Project-level MCP client discovery config belongs in:
 .mcp.json
 ```
 
-Generate it with:
-
-```bash
-aihil mcp-config > .mcp.json
+```json
+{
+  "mcpServers": {
+    "aihil": {
+      "command": "aihil",
+      "args": ["mcp-stdio", "--config", ".aihil/config.yaml"]
+    }
+  }
+}
 ```
+
+The same template is shipped with the package under `dist/templates/mcp.json`. If the MCP client cannot resolve `aihil` from `PATH`, edit `.mcp.json` for that machine instead of changing the project template.
 
 Use the configured COM MCP tools for serial stimuli and feedback. Do not open host COM devices directly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `aihil mcp-config` with a shipped portable MCP template at `dist/templates/mcp.json`.
+
 ## [0.2.1] - 2026-06-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,9 @@ From the firmware project directory:
 ```bash
 aihil init
 aihil doctor
-aihil mcp-config > .mcp.json
 ```
 
-The generated MCP config starts the installed Node entrypoint directly. That is equivalent to:
+Use the standard portable `.mcp.json` launch entry when MCP project discovery is needed. It starts:
 
 ```text
 aihil mcp-stdio --config .aihil/config.yaml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The recommended setup path is agent-first: open your firmware project in your MC
 ```text
 Install https://github.com/hp-8472/aihil for this firmware project and use it as the local MCP hardware-in-the-loop bridge.
 
-Do not vendor the AI-HIL source tree into this firmware repository. Install the aihil command, return to this firmware project, create a project-local .aihil/config.yaml with aihil init, validate it with aihil doctor, generate .mcp.json, and then use AI-HIL for probe, flash, reset, reports, and configured serial feedback.
+Do not vendor the AI-HIL source tree into this firmware repository. Install the aihil command, return to this firmware project, create a project-local .aihil/config.yaml with aihil init, validate it with aihil doctor, add the standard .mcp.json if your MCP client needs project discovery, and then use AI-HIL for probe, flash, reset, reports, and configured serial feedback.
 ```
 
 The agent should install the `aihil` command once on the machine, then configure the current firmware project with its own `.aihil/config.yaml` and `.mcp.json`.
@@ -53,7 +53,19 @@ If you prefer to set it up yourself, run this from your firmware project directo
 npm i -g aihil
 aihil init
 aihil doctor
-aihil mcp-config > .mcp.json
+```
+
+If your MCP client needs a project discovery file, create `.mcp.json` with:
+
+```json
+{
+  "mcpServers": {
+    "aihil": {
+      "command": "aihil",
+      "args": ["mcp-stdio", "--config", ".aihil/config.yaml"]
+    }
+  }
+}
 ```
 
 Each firmware project owns its own `.aihil/` directory. That directory contains the local target configuration, debugger settings, permissions, allowed firmware artifact roots, reports, logs, and optional named COM ports.
@@ -72,7 +84,6 @@ Then return to your firmware project and run:
 ```bash
 aihil init
 aihil doctor
-aihil mcp-config > .mcp.json
 ```
 
 ## First real hardware loop
@@ -112,7 +123,6 @@ git clone https://github.com/hp-8472/aihil.git
 cd aihil/examples/nucleo-f446re_demo
 aihil init
 aihil doctor
-aihil mcp-config > .mcp.json
 ```
 
 The demo includes a prebuilt first-run ELF at:
@@ -202,11 +212,20 @@ AI coding agent
   -> agent uses real hardware feedback for the next firmware change
 ```
 
-AI-HIL uses MCP over stdio internally. Most users should not need to hand-edit MCP details. Generate the project-local MCP config with:
+AI-HIL uses MCP over stdio internally. Most users should not need to hand-edit MCP details. The portable project-local MCP config is:
 
-```bash
-aihil mcp-config > .mcp.json
+```json
+{
+  "mcpServers": {
+    "aihil": {
+      "command": "aihil",
+      "args": ["mcp-stdio", "--config", ".aihil/config.yaml"]
+    }
+  }
+}
 ```
+
+The same template is shipped with the package under `dist/templates/mcp.json`. If the MCP client cannot resolve `aihil` from `PATH`, edit `.mcp.json` for that machine instead of changing the project template.
 
 Agent-facing MCP behavior, tool rules, and safety instructions live in [`AGENTS.md`](AGENTS.md). Human troubleshooting lives in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
 
@@ -306,7 +325,6 @@ The npm package installs the `aihil` CLI. The CLI provides commands such as:
 aihil init
 aihil doctor
 aihil com-ports
-aihil mcp-config
 aihil mcp-stdio
 aihil com-stdio
 ```

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -24,7 +24,7 @@ docs/demo/thumbnail.png
 
 1. Show the connected NUCLEO-F446RE briefly.
 2. Show `aihil doctor` returning `ok: true`.
-3. Show `aihil mcp-config > .mcp.json` or the generated MCP config.
+3. Show the standard portable `.mcp.json` launch config if MCP project discovery is part of the recording.
 4. Show the agent prompt:
 
 ```text

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -3,10 +3,13 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const source = resolve(root, "src", "aihil", "schemas");
-const target = resolve(root, "dist", "schemas");
+const assetDirectories = ["schemas", "templates"];
 
-if (existsSync(source)) {
-  mkdirSync(dirname(target), { recursive: true });
-  cpSync(source, target, { recursive: true });
+for (const directory of assetDirectories) {
+  const source = resolve(root, "src", "aihil", directory);
+  const target = resolve(root, "dist", directory);
+  if (existsSync(source)) {
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(source, target, { recursive: true });
+  }
 }

--- a/skills/aihil-config-setup/SKILL.md
+++ b/skills/aihil-config-setup/SKILL.md
@@ -21,6 +21,22 @@ Use STM32 Nucleo-F446RE, ST-Link, OpenOCD, Node.js 16.16 or newer with npm, `int
 
 If the board, MCU family, debugger interface, target config, COM port, or artifact root cannot be inferred from project files, ask one concise question instead of guessing.
 
+## Fast Nucleo-F446RE Path
+
+When the project and user match the supported first path, skip broad discovery and do this directly:
+
+1. Run `aihil init` if `.aihil/config.yaml` is missing.
+2. Set `target.name: "NUCLEO-F446RE"`, `target.controller: "STM32F446RET6"`, `debugger.interface_cfg: "interface/stlink.cfg"`, and `debugger.target_cfg: "target/stm32f4x.cfg"`.
+3. For ST/STM32 targets, check existing environment variables before hard-coded paths. Prefer `PATH`, `OPENOCD`, `OPENOCD_HOME`, `OPENOCD_SCRIPTS`, `STM32_PROGRAMMER_CLI`, `STM32CUBEIDE_PATH`, and `STLINK_PATH` when they point to an existing OpenOCD/ST-Link toolchain. On Windows, also check `%LOCALAPPDATA%/stm32cube/bundles` for STM32Cube-managed tools such as `programmer/*/bin/STM32_Programmer_CLI.exe`, `stlink-gdbserver/*/bin/ST-LINK_gdbserver.exe`, and `stlink-server/*/bin/stlinkserver.exe`. Derive only supported config values from them, usually `debugger.executable`, `debugger.interface_cfg`, and `debugger.target_cfg`.
+4. If the user gives a COM device, add it directly as `com_ports.dut_uart.device`; set `com_ports.dut_uart.baudrate` to the baud rate configured in the firmware code (`HAL_UART_Init`, LL init structs, register setup, or project UART constants). Use `encoding: "ascii"` unless the project or firmware output requires a different encoding.
+5. Run `aihil doctor`. `.mcp.json` is only the MCP launch configuration, not the tool list. Prefer the stable portable entry shipped as `dist/templates/mcp.json`, which runs `aihil mcp-stdio --config .aihil/config.yaml` when `aihil` is on `PATH`. If the MCP client cannot resolve `aihil`, edit `.mcp.json` for that machine instead of changing reusable project instructions.
+
+For UART smoke tests, start the AI-HIL COM session before the reset or flash that should emit text. Accumulate short reads until the expected substring appears, then stop immediately; avoid fixed multi-second waits unless no data arrives. Once the expected text is observed, do not inspect COM logs or reports unless a failure needs diagnosis.
+
+For AI-HIL 0.2.x, `mcp-stdio` expects newline-delimited JSON-RPC on stdio. Do not use `Content-Length` framing for quick smoke clients.
+
+For tiny STM32 projects, check `ninja` early. If a preset requires Ninja and `ninja` is missing, skip the failing CMake build attempt. When the source set is obvious, a direct `arm-none-eabi-gcc` build into `build/` is an acceptable firmware-build fallback before AI-HIL probe/flash.
+
 Before installing, check `aihil --version`. On Windows, also try `aihil.cmd --version`; if that works, do not reinstall. If `aihil` is not installed because Node.js is missing or too old, install or activate a supported Node.js/npm runtime before running `aihil init`. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless asked; any runtime accepted by `package.json` is fine. Do not refuse the setup for an old Node.js runtime, and do not bypass `engines` with `--force`, `--ignore-engines`, or an older AI-HIL version.
 
 ## Safety Boundaries

--- a/src/aihil/main.ts
+++ b/src/aihil/main.ts
@@ -71,11 +71,6 @@ interface ParsedCommand {
   eofIdleTimeoutS?: number;
 }
 
-interface McpLaunchConfig {
-  command: string;
-  args: string[];
-}
-
 export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (argv.length === 0) {
     process.stderr.write(helpText());
@@ -126,10 +121,6 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     const result = await listAvailableComPorts();
     printJson(result);
     return result.ok ? 0 : 1;
-  }
-  if (args.command === "mcp-config") {
-    printJson(mcpConfig(args.config));
-    return 0;
   }
   if (args.command === "mcp-stdio") {
     return mcpStdio(args.config);
@@ -198,7 +189,7 @@ function initNextSteps(availableComPorts: JsonObject): string[] {
   } else {
     nextSteps.push("COM port discovery failed. Run: aihil com-ports after checking the serialport installation.");
   }
-  nextSteps.push("Run: aihil doctor", "Run: aihil mcp-config > .mcp.json");
+  nextSteps.push("Run: aihil doctor", "Create .mcp.json from the documented portable template if your MCP client needs project discovery.");
   return nextSteps;
 }
 
@@ -241,7 +232,6 @@ export async function doctor(configPath?: string | null): Promise<JsonObject> {
   }
   const debuggerInfo = await createDebuggerBackend(config).info();
   const configDisplayPath = displayPath(config, config.configPath);
-  const mcpLaunch = mcpServerLaunch(configDisplayPath);
   return {
     ok: debuggerInfo.ok === true,
     tool: "aihil_doctor",
@@ -251,8 +241,8 @@ export async function doctor(configPath?: string | null): Promise<JsonObject> {
     config_path: config.configPath,
     mcp: {
       transport: "stdio",
-      command: mcpLaunch.command,
-      args: mcpLaunch.args,
+      command: "aihil",
+      args: ["mcp-stdio", "--config", configDisplayPath],
     },
     target: {
       name: config.target.name,
@@ -265,14 +255,6 @@ export async function doctor(configPath?: string | null): Promise<JsonObject> {
       ]),
     ),
     debugger: debuggerInfo,
-  };
-}
-
-export function mcpConfig(configPath?: string | null): JsonObject {
-  return {
-    mcpServers: {
-      aihil: mcpServerLaunch(configPath ?? DEFAULT_CONFIG_PATH),
-    },
   };
 }
 
@@ -327,13 +309,6 @@ export function installSkill(agent?: string | null, target?: string | null, forc
     source_path: sourcePath,
     target_path: targetPath,
     installed: true,
-  };
-}
-
-function mcpServerLaunch(configPath: string): McpLaunchConfig {
-  return {
-    command: process.execPath,
-    args: [modulePath, "mcp-stdio", "--config", configPath],
   };
 }
 
@@ -443,7 +418,7 @@ function isVersionCommand(command: string | undefined): boolean {
 }
 
 function helpText(): string {
-  return `AI-HIL local MCP stdio server\n\nUsage:\n  aihil <command> [options]\n\nCommands:\n  init [--config <path>] [--force]\n  doctor [--config <path>]\n  com-ports\n  mcp-config [--config <path>]\n  mcp-stdio --config <path>\n  com-stdio --config <path> --port <port_id>\n  schema [--output <path>] [--force]\n  skill-install [--agent opencode] [--target <path>] [--force]\n\nOptions:\n  --help, -h       Show this help.\n  --version, -v    Show the installed version.\n`;
+  return `AI-HIL local MCP stdio server\n\nUsage:\n  aihil <command> [options]\n\nCommands:\n  init [--config <path>] [--force]\n  doctor [--config <path>]\n  com-ports\n  mcp-stdio --config <path>\n  com-stdio --config <path> --port <port_id>\n  schema [--output <path>] [--force]\n  skill-install [--agent opencode] [--target <path>] [--force]\n\nOptions:\n  --help, -h       Show this help.\n  --version, -v    Show the installed version.\n`;
 }
 
 function packageVersion(): string {

--- a/src/aihil/templates/mcp.json
+++ b/src/aihil/templates/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aihil": {
+      "command": "aihil",
+      "args": ["mcp-stdio", "--config", ".aihil/config.yaml"]
+    }
+  }
+}

--- a/tests-ts/run-tests.mjs
+++ b/tests-ts/run-tests.mjs
@@ -9,7 +9,7 @@ import { loadConfig } from "../dist/config.js";
 import { handleMcpMessage } from "../dist/mcp.js";
 import { runStdioServer } from "../dist/stdio.js";
 import { AIHILToolService } from "../dist/tools.js";
-import { initConfig, main, mcpConfig, schema } from "../dist/main.js";
+import { initConfig, main, schema } from "../dist/main.js";
 import { Readable, Writable } from "node:stream";
 import { fc, safePathSegment } from "./property-arbitraries.js";
 
@@ -143,11 +143,11 @@ test("main supports help and version flags", async () => {
   assert.match(version.output.trim(), /^(\d+\.\d+\.\d+|unknown)$/);
 });
 
-test("mcpConfig uses current Node entrypoint", () => {
-  const result = mcpConfig("custom.yaml");
-  assert.equal(result.mcpServers.aihil.command, process.execPath);
-  assert.match(result.mcpServers.aihil.args[0].replace(/\\/g, "/"), /dist\/main\.js$/);
-  assert.deepEqual(result.mcpServers.aihil.args.slice(1), ["mcp-stdio", "--config", "custom.yaml"]);
+test("packaged MCP template is portable", () => {
+  const templatePath = path.join(root, "dist", "templates", "mcp.json");
+  const result = JSON.parse(readFileSync(templatePath, "utf8"));
+  assert.equal(result.mcpServers.aihil.command, "aihil");
+  assert.deepEqual(result.mcpServers.aihil.args, ["mcp-stdio", "--config", ".aihil/config.yaml"]);
 });
 
 test("config loads defaults", () => {


### PR DESCRIPTION
## Summary
- ship a portable MCP discovery template under src/aihil/templates
- remove the redundant mcp-config CLI command
- update setup docs and agent skill guidance for stable .mcp.json usage

## Tests
- npm test