### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-30
+
+### Added
+
+- Added configured CAN MCP tools for listing buses, managing sessions, sending frames, and reading frames through named `bus_id` values.
+- Added PEAK, Linux SocketCAN, and process bridge CAN adapter support so agents can run bounded CAN feedback loops without direct host adapter access.
+- Added CAN configuration schema fields, permissions, and tests for named project-local bus access.
+
 ### Changed
 
 - Replaced `aihil mcp-config` with a shipped portable MCP template at `dist/templates/mcp.json`.
+- Documented CAN setup, MCP tool usage, safety boundaries, and troubleshooting for human and agent workflows.
 
 ## [0.2.1] - 2026-06-28
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "aihil",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aihil",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aihil",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Generic hardware-in-the-loop debugger interface for AI agents",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
## Summary
- Bump package metadata and shrinkwrap to 0.3.0.
- Move CAN MCP adapter support into the 0.3.0 changelog.

## Testing
- npm test
- npm run shrinkwrap:check
- npm run audit:prod
- npm run pack:check
- node scripts/validate-release.mjs v0.3.0
- git diff --check