### PR TITLE
Sync agent skill installs with CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file is for AI coding agents.
 
-Use AI-HIL as the safe local hardware-in-the-loop bridge for embedded projects. AI-HIL gives the agent bounded MCP tools for real hardware actions such as probing, flashing, resetting, reading structured reports, and interacting with configured serial/COM ports and CAN buses.
+Use AI-HIL for embedded firmware development as the safe local hardware-in-the-loop bridge for real embedded targets. AI-HIL gives the agent bounded MCP tools for real hardware actions such as probing, flashing, resetting, reading structured reports, and interacting with configured serial/COM ports and CAN buses.
 
 Do not use raw OpenOCD commands, arbitrary debugger shells, direct host COM-port access, or direct CAN adapter access when an AI-HIL MCP tool is available.
 
@@ -41,12 +41,13 @@ follow this model:
 
 1. Stay aware of the difference between the firmware project and the AI-HIL source repository.
 2. Install the `aihil` command.
-3. Return to the firmware project.
-4. Create or update the project-local `.aihil/config.yaml`.
-5. Validate with `aihil doctor`.
-6. Add the standard portable `.mcp.json` only if the MCP client needs project discovery.
-7. Use AI-HIL MCP tools for hardware actions.
-8. Do not copy or vendor the AI-HIL source tree into the firmware project unless the user explicitly asks for that.
+3. Update and register the agent skill from the installed CLI with `aihil skill-install --agent <agent>` when the active agent supports it. Supported defaults include `opencode`, `claude-code`, and `codex`; use `--target` for other skill-capable agents.
+4. Return to the firmware project.
+5. Create or update the project-local `.aihil/config.yaml`.
+6. Validate with `aihil doctor`.
+7. Add the standard portable `.mcp.json` only if the MCP client needs project discovery.
+8. Use AI-HIL MCP tools for hardware actions.
+9. Do not copy or vendor the AI-HIL source tree into the firmware project unless the user explicitly asks for that.
 
 Before installing, check whether AI-HIL is already available:
 
@@ -213,47 +214,7 @@ Do not mix plain COM text into `mcp-stdio`. MCP stdout must remain JSON-RPC only
 
 ## Available MCP tools
 
-Use `tools/list` to discover the current tool list. The expected AI-HIL tools are:
-
-```text
-aihil_debugger_info
-aihil_probe_target
-aihil_flash_firmware
-aihil_reset_target
-aihil_get_last_report
-aihil_classify_last_error
-aihil_com_ports_list
-aihil_com_session_start
-aihil_com_write
-aihil_com_read
-aihil_com_session_stop
-aihil_can_buses_list
-aihil_can_session_start
-aihil_can_send
-aihil_can_read
-aihil_can_session_stop
-```
-
-Tool intent:
-
-| Tool | Use |
-| --- | --- |
-| `aihil_debugger_info` | Check whether the configured debugger backend is available. |
-| `aihil_probe_target` | Detect the configured embedded target before flashing. |
-| `aihil_flash_firmware` | Flash exactly one validated `image_path` or `artifact_id`. |
-| `aihil_reset_target` | Reset the target with mode `run`, `halt`, or `init`. |
-| `aihil_get_last_report` | Read the most recent structured AI-HIL report. |
-| `aihil_classify_last_error` | Classify the most recent hardware/debugger failure. |
-| `aihil_com_ports_list` | List configured COM ports and detected host serial ports. |
-| `aihil_com_session_start` | Start feedback capture on a configured COM port. |
-| `aihil_com_write` | Send text or hex stimulus to a configured COM session. |
-| `aihil_com_read` | Read buffered serial feedback from a configured COM session. |
-| `aihil_com_session_stop` | Stop and close a configured COM session. |
-| `aihil_can_buses_list` | List configured CAN buses and supported adapter backends. |
-| `aihil_can_session_start` | Start a configured CAN bus session. |
-| `aihil_can_send` | Send one CAN frame through a configured CAN session. |
-| `aihil_can_read` | Read buffered CAN frames from a configured CAN session. |
-| `aihil_can_session_stop` | Stop and close a configured CAN session. |
+Use `tools/list` to discover the current tool list from the running MCP server. `src/aihil/mcp.ts` is authoritative for source-tree development. The installed `aihil` CLI is authoritative for the agent skill version; if they differ, update the skill from the CLI.
 
 ## Required hardware workflow
 
@@ -262,7 +223,7 @@ Use this loop for firmware tasks:
 1. Build the firmware first.
 2. Check debugger availability with `aihil_debugger_info` if setup is unclear.
 3. Probe the target with `aihil_probe_target` before flashing.
-4. Flash only validated artifacts with `aihil_flash_firmware`.
+4. Flash only validated artifacts with `aihil_flash_firmware`; use `aihil_artifact_upload` first when the workflow needs an `artifact_id`.
 5. Reset with `aihil_reset_target` only when needed or requested.
 6. For serial feedback, use configured COM port ids with `aihil_com_session_start`, `aihil_com_write`, `aihil_com_read`, and `aihil_com_session_stop`.
 7. For CAN stimuli or feedback, use configured CAN bus ids with `aihil_can_session_start`, `aihil_can_send`, `aihil_can_read`, and `aihil_can_session_stop`.

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -1,6 +1,6 @@
 # AI Agent Quickstart
 
-Use AI-HIL as the local MCP server for embedded hardware actions.
+Use AI-HIL as the local MCP server for embedded firmware development and embedded hardware actions.
 
 This file is for agents. Humans should start with `README.md` and use `TROUBLESHOOTING.md` for operator-facing diagnostics.
 
@@ -43,7 +43,7 @@ Do not use `--force`, `--ignore-engines`, or an older AI-HIL version to bypass t
 
 ## Install Agent Skill
 
-Agent-driven AI-HIL installation includes installing `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed.
+Agent-driven AI-HIL installation includes installing the matching `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed. The installed CLI is authoritative: if the skill front matter version differs from `aihil --version`, update the skill from the CLI with `aihil skill-install --agent <agent>`.
 
 If this source checkout is not available, clone or fetch the AI-HIL repository outside the firmware project only for the skill source, then remove that temporary checkout if it is no longer needed.
 
@@ -51,8 +51,11 @@ Known user-level skill destinations:
 
 - opencode: `$HOME/.config/opencode/skills/aihil-config-setup/SKILL.md`.
 - Claude Code: `$HOME/.claude/skills/aihil-config-setup/SKILL.md`.
+- Codex: `$HOME/.codex/skills/aihil-config-setup/SKILL.md`.
 
-For other skill-capable agents, use that agent's documented user-level skill directory. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
+`skill-install` also performs the known registration step for the selected agent. opencode and Claude Code discover skills from their skill directories. Codex additionally gets a marked AI-HIL block in `$HOME/.codex/AGENTS.md` pointing at the installed skill.
+
+CLI-supported agent names and aliases are `opencode`/`open-code`, `claude-code`/`claude`, and `codex`/`codex-cli`/`openai-codex`. For other skill-capable agents, use that agent's documented user-level skill directory with `aihil skill-install --agent <name> --target <path>`. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
 
 Do not rely on npm for skills, and do not add npm `postinstall` hooks for skill installation. Skill installation is an agent workflow responsibility, not package-manager behavior.
 
@@ -134,12 +137,13 @@ Do not mix plain COM text into `aihil mcp-stdio`; MCP stdio must remain JSON-RPC
 Use `tools/list` to discover available MCP tools, then follow this loop:
 
 1. Build firmware.
-2. Probe with `aihil_probe_target`.
-3. Flash with `aihil_flash_firmware` using `image_path`, usually `build/firmware.elf`, or first call `aihil_artifact_upload` with `image_path` and flash the returned `artifact_id`.
-4. For serial feedback, start `aihil_com_session_start`, send stimuli with `aihil_com_write`, read feedback with `aihil_com_read`, then stop with `aihil_com_session_stop`.
-5. For CAN feedback, start `aihil_can_session_start`, send frames with `aihil_can_send`, read frames with `aihil_can_read`, then stop with `aihil_can_session_stop`.
-6. Read the tool result and `aihil_get_last_report`.
-7. Diagnose failures with `aihil_classify_last_error`.
+2. Check debugger availability with `aihil_debugger_info` if setup is unclear.
+3. Probe with `aihil_probe_target`.
+4. Flash with `aihil_flash_firmware` using `image_path`, usually `build/firmware.elf`, or first call `aihil_artifact_upload` with `image_path` and flash the returned `artifact_id`.
+5. For serial feedback, start `aihil_com_session_start`, send stimuli with `aihil_com_write`, read feedback with `aihil_com_read`, then stop with `aihil_com_session_stop`.
+6. For CAN feedback, start `aihil_can_session_start`, send frames with `aihil_can_send`, read frames with `aihil_can_read`, then stop with `aihil_can_session_stop`.
+7. Read the tool result and `aihil_get_last_report`.
+8. Diagnose failures with `aihil_classify_last_error`.
 
 Do not use raw OpenOCD commands, arbitrary COM port shell tools, or direct CAN adapter tools when an AI-HIL MCP tool is available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - Replaced `aihil mcp-config` with a shipped portable MCP template at `dist/templates/mcp.json`.
 - Documented CAN setup, MCP tool usage, safety boundaries, and troubleshooting for human and agent workflows.
+- Made MCP `initialize` report the package version instead of a stale hard-coded server version.
+- Tied the agent setup skill to the AI-HIL package version and made the installed CLI authoritative for skill updates.
+- Included the setup skill in the npm package so `aihil skill-install` can update version-drifted AI-HIL skills from the installed CLI.
+- Added `aihil skill-install` support for opencode, Claude Code, Codex, common aliases, and explicit custom target paths.
 
 ## [0.2.1] - 2026-06-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Canonical agent instructions live in `AGENTS.md` and `AI_AGENT_QUICKSTART.md`. H
 
 ## Project Overview
 
-AI-HIL is a TypeScript/Node.js MCP stdio server for safe embedded hardware-in-the-loop access. It exposes narrow tools for probing, flashing, resetting, configured COM port stimulus/feedback, configured CAN bus stimulus/feedback, and reading structured reports from a configured local target.
+AI-HIL is a TypeScript/Node.js MCP stdio server for safe embedded firmware development with local hardware-in-the-loop targets. It exposes narrow tools for probing, flashing, resetting, configured COM port stimulus/feedback, configured CAN bus stimulus/feedback, and reading structured reports from a configured local embedded target.
 
 Use STM32 Nucleo-F446RE + ST-Link + OpenOCD + Node.js 16.16 or newer with npm as the supported first path unless project files or the user clearly identify another setup. Current Node.js LTS is recommended.
 
@@ -35,7 +35,7 @@ Do not work around an old runtime with `--force`, `--ignore-engines`, or an olde
 
 ## Agent Skill Installation
 
-Agent-driven AI-HIL installation includes installing `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed.
+Agent-driven AI-HIL installation includes installing the matching `skills/aihil-config-setup/SKILL.md` into the active agent's user-level skill directory after the `aihil` command is installed. The installed CLI is authoritative: if the skill front matter version differs from `aihil --version`, update the skill from the CLI with `aihil skill-install --agent claude-code`.
 
 If this source checkout is not available, clone or fetch the AI-HIL repository outside the firmware project only for the skill source, then remove that temporary checkout if it is no longer needed.
 
@@ -43,8 +43,11 @@ Known user-level skill destinations:
 
 - opencode: `$HOME/.config/opencode/skills/aihil-config-setup/SKILL.md`.
 - Claude Code: `$HOME/.claude/skills/aihil-config-setup/SKILL.md`.
+- Codex: `$HOME/.codex/skills/aihil-config-setup/SKILL.md`.
 
-For other skill-capable agents, use that agent's documented user-level skill directory. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
+`skill-install` also performs the known registration step for the selected agent. opencode and Claude Code discover skills from their skill directories. Codex additionally gets a marked AI-HIL block in `$HOME/.codex/AGENTS.md` pointing at the installed skill.
+
+CLI-supported agent names and aliases are `opencode`/`open-code`, `claude-code`/`claude`, and `codex`/`codex-cli`/`openai-codex`. For other skill-capable agents, use that agent's documented user-level skill directory with `aihil skill-install --agent <name> --target <path>`. If the active agent has no skill mechanism or the destination cannot be determined, ask one concise question instead of silently skipping skill installation.
 
 Do not rely on npm for skills, and do not add npm `postinstall` hooks for skill installation. Skill installation is an agent workflow responsibility, not package-manager behavior.
 
@@ -98,13 +101,14 @@ Use the AI-HIL MCP tools for hardware actions. Do not use raw OpenOCD commands o
 Follow this sequence for hardware validation:
 
 1. Build firmware.
-2. Call `aihil_probe_target`.
-3. Call `aihil_flash_firmware` with a validated artifact path, usually `build/firmware.elf`, or upload first with `aihil_artifact_upload` using `image_path` and flash the returned `artifact_id`.
-4. For serial stimuli or feedback, use only configured port ids with `aihil_com_session_start`, `aihil_com_write`, `aihil_com_read`, and `aihil_com_session_stop`.
-5. For CAN stimuli or feedback, use only configured bus ids with `aihil_can_session_start`, `aihil_can_send`, `aihil_can_read`, and `aihil_can_session_stop`.
-6. Read the returned JSON result.
-7. Call `aihil_get_last_report`.
-8. Call `aihil_classify_last_error` after failed actions.
+2. Call `aihil_debugger_info` if setup is unclear.
+3. Call `aihil_probe_target`.
+4. Call `aihil_flash_firmware` with a validated artifact path, usually `build/firmware.elf`, or upload first with `aihil_artifact_upload` using `image_path` and flash the returned `artifact_id`.
+5. For serial stimuli or feedback, use only configured port ids with `aihil_com_session_start`, `aihil_com_write`, `aihil_com_read`, and `aihil_com_session_stop`.
+6. For CAN stimuli or feedback, use only configured bus ids with `aihil_can_session_start`, `aihil_can_send`, `aihil_can_read`, and `aihil_can_session_stop`.
+7. Read the returned JSON result.
+8. Call `aihil_get_last_report`.
+9. Call `aihil_classify_last_error` after failed actions.
 
 Stop on `permission_denied` and report the local policy restriction.
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "docs/demo/README.md",
     "AGENTS.md",
     "AI_AGENT_QUICKSTART.md",
+    "skills/aihil-config-setup/SKILL.md",
     "LICENSE"
   ],
   "dependencies": {

--- a/skills/aihil-config-setup/SKILL.md
+++ b/skills/aihil-config-setup/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: aihil-config-setup
-description: Create and validate a project-local .aihil/config.yaml for AI-HIL without weakening hardware safety policy.
+description: Create and validate a project-local .aihil/config.yaml for AI-HIL embedded firmware hardware-in-the-loop workflows without weakening hardware safety policy.
 metadata:
   origin: AI-HIL
+  aihil_version: "0.3.0"
 ---
 
 # AI-HIL Config Setup
 
-Use this skill when a user asks to set up AI-HIL for a firmware project, create `.aihil/config.yaml`, fix AI-HIL configuration errors, or prepare a project for the local AI-HIL MCP server.
+Use this skill when a user asks to set up AI-HIL for an embedded firmware project, create `.aihil/config.yaml`, fix AI-HIL configuration errors, or prepare a project for the local AI-HIL MCP server.
 
 ## Core Rule
 
@@ -34,11 +35,17 @@ When the project and user match the supported first path, skip broad discovery a
 
 For UART smoke tests, start the AI-HIL COM session before the reset or flash that should emit text. Accumulate short reads until the expected substring appears, then stop immediately; avoid fixed multi-second waits unless no data arrives. Once the expected text is observed, do not inspect COM logs or reports unless a failure needs diagnosis.
 
-For AI-HIL 0.2.x, `mcp-stdio` expects newline-delimited JSON-RPC on stdio. Do not use `Content-Length` framing for quick smoke clients.
+For AI-HIL 0.3.x, `mcp-stdio` expects newline-delimited JSON-RPC on stdio. Do not use `Content-Length` framing for quick smoke clients.
 
 For tiny STM32 projects, check `ninja` early. If a preset requires Ninja and `ninja` is missing, skip the failing CMake build attempt. When the source set is obvious, a direct `arm-none-eabi-gcc` build into `build/` is an acceptable firmware-build fallback before AI-HIL probe/flash.
 
 Before installing, check `aihil --version`. On Windows, also try `aihil.cmd --version`; if that works, do not reinstall. If `aihil` is not installed because Node.js is missing or too old, install or activate a supported Node.js/npm runtime before running `aihil init`. Current Node.js LTS is fine, but do not pin a specific Node.js patch version unless asked; any runtime accepted by `package.json` is fine. Do not refuse the setup for an old Node.js runtime, and do not bypass `engines` with `--force`, `--ignore-engines`, or an older AI-HIL version.
+
+## Version Contract
+
+This skill is tied to the AI-HIL version in its front matter. The installed `aihil` CLI is authoritative. If the skill version differs from `aihil --version`, update and register the skill from the installed CLI with `aihil skill-install --agent <agent>`; do not downgrade the CLI to match an older skill. Supported defaults include `opencode`, `claude-code`, and `codex`; use `--target` for other skill-capable agents.
+
+Use `tools/list` as the runtime source of truth for MCP tools. This setup skill should not probe, flash, reset, or open COM sessions unless the user asks for hardware validation.
 
 ## Safety Boundaries
 

--- a/src/aihil/main.ts
+++ b/src/aihil/main.ts
@@ -9,6 +9,7 @@ import { ConfigError, configSchemaText, DEFAULT_CONFIG_PATH, displayPath, loadCo
 import { createDebuggerBackend } from "./debugger.js";
 import { runStdioServer } from "./stdio.js";
 import type { JsonObject } from "./types.js";
+import { packageVersion } from "./version.js";
 
 export const DEFAULT_CONFIG_TEMPLATE = `target:
   name: "example-target"
@@ -74,6 +75,43 @@ interface ParsedCommand {
   readWaitTimeoutS?: number;
   eofIdleTimeoutS?: number;
 }
+
+interface SkillAgent {
+  id: string;
+  displayName: string;
+  aliases: string[];
+  defaultTargetPath: () => string;
+  registration: "skills-directory" | "agents-md";
+}
+
+const SKILL_NAME = "aihil-config-setup";
+const SKILL_FILE = "SKILL.md";
+const AIHIL_REGISTRATION_START = "<!-- AI-HIL skill registration start -->";
+const AIHIL_REGISTRATION_END = "<!-- AI-HIL skill registration end -->";
+
+const SKILL_AGENTS: SkillAgent[] = [
+  {
+    id: "opencode",
+    displayName: "opencode",
+    aliases: ["opencode", "open-code"],
+    defaultTargetPath: () => path.join(homedir(), ".config", "opencode", "skills", SKILL_NAME, SKILL_FILE),
+    registration: "skills-directory",
+  },
+  {
+    id: "claude-code",
+    displayName: "Claude Code",
+    aliases: ["claude-code", "claude", "claude_code"],
+    defaultTargetPath: () => path.join(homedir(), ".claude", "skills", SKILL_NAME, SKILL_FILE),
+    registration: "skills-directory",
+  },
+  {
+    id: "codex",
+    displayName: "Codex",
+    aliases: ["codex", "codex-cli", "openai-codex"],
+    defaultTargetPath: () => path.join(homedir(), ".codex", "skills", SKILL_NAME, SKILL_FILE),
+    registration: "agents-md",
+  },
+];
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (argv.length === 0) {
@@ -270,57 +308,187 @@ export async function doctor(configPath?: string | null): Promise<JsonObject> {
 }
 
 export function installSkill(agent?: string | null, target?: string | null, force = false): JsonObject {
-  const resolvedAgent = agent ?? "opencode";
-  if (resolvedAgent !== "opencode") {
+  const requestedAgent = agent ?? "opencode";
+  const resolvedAgent = resolveSkillAgent(requestedAgent);
+  if (!resolvedAgent && !target) {
     return {
       ok: false,
       error_type: "unsupported_agent",
-      summary: "AI-HIL can currently install skills only for opencode.",
-      agent: resolvedAgent,
-      allowed_agents: ["opencode"],
+      summary: "AI-HIL does not know this agent's default skill directory. Provide --target to install anyway.",
+      agent: normalizeAgent(requestedAgent),
+      allowed_agents: supportedSkillAgents(),
     };
   }
+  const agentId = resolvedAgent?.id ?? normalizeAgent(requestedAgent);
+  const agentName = resolvedAgent?.displayName ?? agentId;
 
   const sourcePath = bundledSkillPath();
-  const targetPath = target ?? defaultOpencodeSkillPath();
+  const targetPath = target ?? resolvedAgent!.defaultTargetPath();
   const sourceText = readFileSync(sourcePath, "utf8");
+  const sourceVersion = skillVersion(sourceText) ?? packageVersion();
   if (existsSync(targetPath)) {
     const existingText = readFileSync(targetPath, "utf8");
     if (existingText === sourceText) {
+      const registration = registerSkill(resolvedAgent, targetPath, sourceVersion, requestedAgent);
       return {
         ok: true,
-        summary: "AI-HIL opencode skill is already installed.",
-        agent: resolvedAgent,
-        skill: "aihil-config-setup",
+        summary: `AI-HIL ${agentName} skill is already installed.`,
+        agent: agentId,
+        requested_agent: requestedAgent,
+        skill: SKILL_NAME,
         source_path: sourcePath,
         target_path: targetPath,
+        version: sourceVersion,
         installed: false,
+        updated: false,
+        registered: registration?.ok === true,
+        registration,
+      };
+    }
+    const existingVersion = skillVersion(existingText);
+    if (isAihilSetupSkill(existingText) && existingVersion !== sourceVersion) {
+      mkdirSync(path.dirname(targetPath), { recursive: true });
+      writeFileSync(targetPath, sourceText, "utf8");
+      const registration = registerSkill(resolvedAgent, targetPath, sourceVersion, requestedAgent);
+      return {
+        ok: true,
+        summary: `AI-HIL ${agentName} skill updated to match the installed CLI.`,
+        agent: agentId,
+        requested_agent: requestedAgent,
+        skill: SKILL_NAME,
+        source_path: sourcePath,
+        target_path: targetPath,
+        previous_version: existingVersion,
+        version: sourceVersion,
+        installed: false,
+        updated: true,
+        registered: registration?.ok === true,
+        registration,
       };
     }
     if (!force) {
       return {
         ok: false,
         error_type: "skill_exists",
-        summary: "Target skill file already exists with different content. Use --force to overwrite it.",
-        agent: resolvedAgent,
-        skill: "aihil-config-setup",
+        summary: "Target skill file already exists with different content and no CLI-version drift. Use --force to overwrite it.",
+        agent: agentId,
+        requested_agent: requestedAgent,
+        skill: SKILL_NAME,
         source_path: sourcePath,
         target_path: targetPath,
+        existing_version: existingVersion,
+        version: sourceVersion,
       };
     }
   }
 
   mkdirSync(path.dirname(targetPath), { recursive: true });
   writeFileSync(targetPath, sourceText, "utf8");
+  const registration = registerSkill(resolvedAgent, targetPath, sourceVersion, requestedAgent);
   return {
     ok: true,
-    summary: "AI-HIL opencode skill installed.",
-    agent: resolvedAgent,
-    skill: "aihil-config-setup",
+    summary: `AI-HIL ${agentName} skill installed.`,
+    agent: agentId,
+    requested_agent: requestedAgent,
+    skill: SKILL_NAME,
     source_path: sourcePath,
     target_path: targetPath,
+    version: sourceVersion,
     installed: true,
+    updated: false,
+    registered: registration?.ok === true,
+    registration,
   };
+}
+
+function skillVersion(text: string): string | null {
+  const match = /^  aihil_version: "([^"]+)"$/m.exec(text);
+  return match?.[1] ?? null;
+}
+
+function isAihilSetupSkill(text: string): boolean {
+  return new RegExp(`^name: ${SKILL_NAME}$`, "m").test(text) && /^  origin: AI-HIL$/m.test(text);
+}
+
+function normalizeAgent(agent: string): string {
+  return agent.trim().toLowerCase().replace(/_/g, "-");
+}
+
+function resolveSkillAgent(agent: string): SkillAgent | null {
+  const normalized = normalizeAgent(agent);
+  return SKILL_AGENTS.find((candidate) => candidate.aliases.map(normalizeAgent).includes(normalized)) ?? null;
+}
+
+function supportedSkillAgents(): string[] {
+  return SKILL_AGENTS.map((agent) => agent.id);
+}
+
+function registerSkill(agent: SkillAgent | null, targetPath: string, version: string, requestedAgent: string): JsonObject | null {
+  if (!agent) {
+    return {
+      ok: false,
+      mode: "explicit-target",
+      summary: "No automatic agent registration is known for this agent. The skill was written to the explicit target path.",
+    };
+  }
+  if (agent.registration === "skills-directory") {
+    return {
+      ok: true,
+      mode: "skills-directory",
+      summary: `${agent.displayName} discovers installed skills from its skills directory.`,
+      path: path.dirname(targetPath),
+    };
+  }
+
+  const registrationPath = path.join(skillInstallRoot(targetPath), "AGENTS.md");
+  const block = codexRegistrationBlock(targetPath, version, requestedAgent);
+  const result = upsertMarkedBlock(registrationPath, block);
+  return {
+    ok: true,
+    mode: "agents-md",
+    summary: `${agent.displayName} registration written to AGENTS.md.`,
+    path: registrationPath,
+    updated: result.updated,
+  };
+}
+
+function skillInstallRoot(targetPath: string): string {
+  const skillDirectory = path.dirname(targetPath);
+  const skillsDirectory = path.dirname(skillDirectory);
+  if (path.basename(targetPath) === SKILL_FILE && path.basename(skillDirectory) === SKILL_NAME && path.basename(skillsDirectory) === "skills") {
+    return path.dirname(skillsDirectory);
+  }
+  return path.dirname(targetPath);
+}
+
+function codexRegistrationBlock(targetPath: string, version: string, requestedAgent: string): string {
+  return `${AIHIL_REGISTRATION_START}
+## AI-HIL Skill
+
+- Skill path: \`${targetPath}\`
+- AI-HIL version: \`${version}\`
+- AI-HIL is for embedded firmware development with local hardware-in-the-loop targets.
+- For AI-HIL setup, configuration, MCP, or embedded hardware workflows, read and follow this skill before acting.
+- If this version differs from \`aihil --version\`, run \`aihil skill-install --agent ${requestedAgent}\` and use the installed CLI as authoritative.
+${AIHIL_REGISTRATION_END}`;
+}
+
+function upsertMarkedBlock(filePath: string, block: string): { updated: boolean } {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const existing = existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+  const blockPattern = new RegExp(`${escapeRegExp(AIHIL_REGISTRATION_START)}[\\s\\S]*?${escapeRegExp(AIHIL_REGISTRATION_END)}`);
+  const next = blockPattern.test(existing)
+    ? existing.replace(blockPattern, block)
+    : `${existing.trimEnd()}${existing.trimEnd() ? "\n\n" : ""}${block}\n`;
+  if (next !== existing) {
+    writeFileSync(filePath, next, "utf8");
+    return { updated: true };
+  }
+  return { updated: false };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export async function mcpStdio(configPath?: string | null): Promise<number> {
@@ -429,28 +597,11 @@ function isVersionCommand(command: string | undefined): boolean {
 }
 
 function helpText(): string {
-  return `AI-HIL local MCP stdio server\n\nUsage:\n  aihil <command> [options]\n\nCommands:\n  init [--config <path>] [--force]\n  doctor [--config <path>]\n  com-ports\n  mcp-stdio --config <path>\n  com-stdio --config <path> --port <port_id>\n  schema [--output <path>] [--force]\n  skill-install [--agent opencode] [--target <path>] [--force]\n\nOptions:\n  --help, -h       Show this help.\n  --version, -v    Show the installed version.\n`;
-}
-
-function packageVersion(): string {
-  const packagePath = path.resolve(path.dirname(modulePath), "..", "package.json");
-  try {
-    const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as { version?: unknown };
-    if (typeof packageJson.version === "string") {
-      return packageJson.version;
-    }
-  } catch {
-    // Fall through to a stable value when running from an unusual layout.
-  }
-  return "unknown";
+  return `AI-HIL local MCP stdio server\n\nUsage:\n  aihil <command> [options]\n\nCommands:\n  init [--config <path>] [--force]\n  doctor [--config <path>]\n  com-ports\n  mcp-stdio --config <path>\n  com-stdio --config <path> --port <port_id>\n  schema [--output <path>] [--force]\n  skill-install [--agent <${supportedSkillAgents().join("|")}>] [--target <path>] [--force]\n\nOptions:\n  --help, -h       Show this help.\n  --version, -v    Show the installed version.\n`;
 }
 
 function bundledSkillPath(): string {
   return path.resolve(path.dirname(modulePath), "..", "skills", "aihil-config-setup", "SKILL.md");
-}
-
-function defaultOpencodeSkillPath(): string {
-  return path.join(homedir(), ".config", "opencode", "skills", "aihil-config-setup", "SKILL.md");
 }
 
 const invokedPath = process.argv[1] ? realpathOrResolve(process.argv[1]) : null;

--- a/src/aihil/mcp.ts
+++ b/src/aihil/mcp.ts
@@ -1,5 +1,6 @@
 import type { JsonObject } from "./types.js";
 import type { AIHILToolService } from "./tools.js";
+import { packageVersion } from "./version.js";
 
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -290,13 +291,14 @@ const AIHIL_WORKFLOW_PROMPT = `Use AI-HIL as the safe gate to the configured emb
 
 Workflow:
 1. Build the firmware first.
-2. Probe the target before flashing.
-3. Flash only validated artifacts from configured allowed roots.
-4. Read the structured result after every hardware action.
-5. Reset only when needed or when the task explicitly requires it.
-6. For serial stimuli and feedback, use only configured COM port ids, start a session before writing or reading, and stop the session when done.
-7. For CAN stimuli and feedback, use only configured CAN bus ids, start a CAN session before sending or reading frames, and stop the session when done.
-8. If ok is false, diagnose using error_type, backend_error_type, likely_causes, report_path, and log_path before changing code again.
+2. Check debugger availability with aihil_debugger_info if setup is unclear.
+3. Probe the target before flashing.
+4. Flash with a validated image_path from configured allowed roots, or upload first with aihil_artifact_upload when you need an artifact_id.
+5. Read the structured result after every hardware action.
+6. Reset only when needed or when the task explicitly requires it.
+7. For serial stimuli and feedback, use only configured COM port ids, start a session before writing or reading, and stop the session when done.
+8. For CAN stimuli and feedback, use only configured CAN bus ids, start a CAN session before sending or reading frames, and stop the session when done.
+9. If ok is false, diagnose using error_type, backend_error_type, likely_causes, report_path, and log_path before changing code again.
 
 Safety rules:
 - Do not request raw OpenOCD or debugger commands.
@@ -370,7 +372,7 @@ async function handleMethod(requestId: unknown, method: string, params: unknown,
       },
       serverInfo: {
         name: "aihil",
-        version: "0.1.0",
+        version: packageVersion(),
       },
     });
   }

--- a/src/aihil/version.ts
+++ b/src/aihil/version.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function packageVersion(): string {
+  const packagePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+  try {
+    const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as { version?: unknown };
+    if (typeof packageJson.version === "string") {
+      return packageJson.version;
+    }
+  } catch {
+    // Fall through to a stable value when running from an unusual layout.
+  }
+  return "unknown";
+}

--- a/tests-ts/run-tests.mjs
+++ b/tests-ts/run-tests.mjs
@@ -9,7 +9,7 @@ import { loadConfig } from "../dist/config.js";
 import { handleMcpMessage } from "../dist/mcp.js";
 import { runStdioServer } from "../dist/stdio.js";
 import { AIHILToolService } from "../dist/tools.js";
-import { initConfig, main, schema } from "../dist/main.js";
+import { initConfig, installSkill, main, schema } from "../dist/main.js";
 import { Readable, Writable } from "node:stream";
 import { fc, safePathSegment } from "./property-arbitraries.js";
 
@@ -112,6 +112,30 @@ async function mcpToolCall(service, name, arguments_ = {}) {
   return response.result.structuredContent;
 }
 
+function packageMetadata() {
+  return JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+}
+
+function skillAihilVersion() {
+  const text = readFileSync(path.join(root, "skills", "aihil-config-setup", "SKILL.md"), "utf8");
+  const match = /^  aihil_version: "([^"]+)"$/m.exec(text);
+  assert.ok(match, "skill front matter must declare metadata.aihil_version");
+  return match[1];
+}
+
+function oldAihilSkill(version = "0.0.0") {
+  return `---
+name: aihil-config-setup
+description: old skill
+metadata:
+  origin: AI-HIL
+  aihil_version: "${version}"
+---
+
+# Old AI-HIL Skill
+`;
+}
+
 test("initConfig writes starter config", async () => {
   const directory = tempDir();
   try {
@@ -151,6 +175,79 @@ test("packaged MCP template is portable", () => {
   const result = JSON.parse(readFileSync(templatePath, "utf8"));
   assert.equal(result.mcpServers.aihil.command, "aihil");
   assert.deepEqual(result.mcpServers.aihil.args, ["mcp-stdio", "--config", ".aihil/config.yaml"]);
+});
+
+test("agent skill version matches package version", () => {
+  assert.equal(skillAihilVersion(), packageMetadata().version);
+});
+
+test("package ships agent setup skill for CLI-driven updates", () => {
+  assert.ok(packageMetadata().files.includes("skills/aihil-config-setup/SKILL.md"));
+});
+
+test("skill install updates AI-HIL skill version drift", () => {
+  const directory = tempDir();
+  try {
+    const target = path.join(directory, "skills", "aihil-config-setup", "SKILL.md");
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, oldAihilSkill(), "utf8");
+
+    const result = installSkill("opencode", target);
+    assert.equal(result.ok, true);
+    assert.equal(result.updated, true);
+    assert.equal(result.previous_version, "0.0.0");
+    assert.equal(result.version, packageMetadata().version);
+    assert.equal(readFileSync(target, "utf8"), readFileSync(path.join(root, "skills", "aihil-config-setup", "SKILL.md"), "utf8"));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("skill install supports common agent aliases", () => {
+  const directory = tempDir();
+  try {
+    const cases = [
+      ["opencode", "opencode"],
+      ["open-code", "opencode"],
+      ["claude-code", "claude-code"],
+      ["claude", "claude-code"],
+      ["codex", "codex"],
+      ["codex-cli", "codex"],
+      ["openai-codex", "codex"],
+    ];
+    for (const [agent, expected] of cases) {
+      const target = path.join(directory, String(agent), "SKILL.md");
+      const result = installSkill(String(agent), target);
+      assert.equal(result.ok, true);
+      assert.equal(result.agent, expected);
+      assert.equal(result.target_path, target);
+      assert.equal(readFileSync(target, "utf8"), readFileSync(path.join(root, "skills", "aihil-config-setup", "SKILL.md"), "utf8"));
+      if (expected === "codex") {
+        const registration = readFileSync(path.join(path.dirname(target), "AGENTS.md"), "utf8");
+        assert.match(registration, /AI-HIL is for embedded firmware development/);
+        assert.match(registration, new RegExp(target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      }
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("skill install supports explicit target for unknown agents", () => {
+  const directory = tempDir();
+  try {
+    const target = path.join(directory, "custom", "SKILL.md");
+    const installed = installSkill("cursor", target);
+    assert.equal(installed.ok, true);
+    assert.equal(installed.agent, "cursor");
+
+    const rejected = installSkill("cursor");
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error_type, "unsupported_agent");
+    assert.deepEqual(rejected.allowed_agents, ["opencode", "claude-code", "codex"]);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("config loads defaults", () => {
@@ -464,6 +561,7 @@ test("mcp initialize and tools/list", async () => {
     await withService(directory, async (service) => {
       const initialized = await handleMcpMessage({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }, service);
       assert.equal(initialized.result.serverInfo.name, "aihil");
+      assert.equal(initialized.result.serverInfo.version, packageMetadata().version);
       const listed = await handleMcpMessage({ jsonrpc: "2.0", id: "tools", method: "tools/list" }, service);
       const toolNames = new Set(listed.result.tools.map((tool) => tool.name));
       assert.equal(toolNames.has("aihil_probe_target"), true);


### PR DESCRIPTION
## Summary
- make the installed CLI authoritative for agent skill versioning and MCP server version reporting
- add skill-install support for opencode, Claude Code, Codex, aliases, and explicit target paths
- register Codex through a marked AGENTS.md block and keep embedded firmware context visible in LLM-facing docs

## Tests
- npm test
- npm run pack:check