### PR TITLE
Document npm exec setup in v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Changed
 
 - Made MCP `initialize` report the package version instead of a stale hard-coded server version.
+- Switched generated setup guidance and the portable MCP template to `npm exec --package aihil` so users can run AI-HIL without a global install or PATH changes.
 - Tied the agent setup skill to the AI-HIL package version and made the installed CLI authoritative for skill updates.
 - Included the setup skill in the npm package so `aihil skill-install` can update version-drifted AI-HIL skills from the installed CLI.
 - Added `aihil skill-install` support for opencode, Claude Code, Codex, common aliases, and explicit custom target paths.


### PR DESCRIPTION
## Summary
- Add the npm exec setup/template change from PR 35 to the v0.4.0 changelog before tagging.

## Testing
- node scripts/validate-release.mjs v0.4.0
- git diff --check