### PR TITLE
chore: align Agentic HIL public metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible HardCI setup, hardware, CLI, MCP, or COM failure.
+description: Report a reproducible Agentic HIL setup, hardware, CLI, MCP, or COM failure.
 title: "bug: "
 labels:
   - bug
@@ -7,12 +7,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for testing HardCI. Please include structured details so the issue can be reproduced safely. For common setup failures, check TROUBLESHOOTING.md first.
+        Thanks for testing Agentic HIL. Please include structured details so the issue can be reproduced safely. For common setup failures, check TROUBLESHOOTING.md first.
   - type: input
     id: version
     attributes:
-      label: HardCI version
-      description: Run `hardci --version` if available, or provide the PyPI package version / git commit.
+      label: Agentic HIL version
+      description: Run `agentic-hil --version` if available, or provide the PyPI package version / git commit.
       placeholder: "0.1.0"
     validations:
       required: true
@@ -21,9 +21,9 @@ body:
     attributes:
       label: Installation method
       options:
-        - pip install hardci
-        - pipx install hardci
-        - uv tool install hardci
+        - pip install agentic-hil
+        - pipx install agentic-hil
+        - uv tool install agentic-hil
         - pip install from git checkout
         - other
     validations:
@@ -68,8 +68,8 @@ body:
       label: Reproduction steps
       description: Include exact commands and MCP tool calls if applicable.
       placeholder: |
-        1. hardci init
-        2. hardci doctor
+        1. agentic-hil init
+        2. agentic-hil doctor
         3. Agent called hardci_probe_target
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Troubleshooting guide
-    url: https://github.com/hp-8472/hardci/blob/main/TROUBLESHOOTING.md
+    url: https://github.com/hp-8472/agentic-hil/blob/master/TROUBLESHOOTING.md
     about: Start here for debugger, target detection, artifact validation, and COM-port setup failures.
   - name: Security policy
-    url: https://github.com/hp-8472/hardci/security/policy
+    url: https://github.com/hp-8472/agentic-hil/security/policy
     about: Report security issues and hardware-safety concerns through the documented security process.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Propose a scoped HardCI workflow, backend, safety, docs, or packaging improvement.
+description: Propose a scoped Agentic HIL workflow, backend, safety, docs, or packaging improvement.
 title: "feature: "
 labels:
   - enhancement
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        HardCI should stay local-first, MCP-native, and safe for agent-driven hardware workflows.
+        Agentic HIL should stay local-first, MCP-native, and safe for agent-driven hardware workflows.
   - type: textarea
     id: problem
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ name: Python CI
 on:
   push:
     branches:
+      - master
       - main
   pull_request:
     branches:
+      - master
       - main
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,11 @@ name: CodeQL
 on:
   push:
     branches:
+      - master
       - main
   pull_request:
     branches:
+      - master
       - main
   workflow_dispatch:
   schedule:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -9,6 +9,7 @@ on:
     types:
       - completed
     branches:
+      - master
       - main
   schedule:
     - cron: "31 3 * * 1"

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -4,6 +4,12 @@ Use Agentic HIL as the local MCP server for embedded firmware development and em
 
 This file is for agents. Humans should start with `README.md` and use `TROUBLESHOOTING.md` for operator-facing diagnostics.
 
+Canonical copy/paste user request:
+
+```text
+Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.
+```
+
 If you were given only the Agentic HIL repository URL and asked to set it up: run the fast path below, install the Agentic HIL skill into your own skill directory, configure the firmware project, then return to the firmware project. Do not clone, checkout, or vendor the Agentic HIL source tree into the firmware project for normal setup.
 
 ## Ground Rules
@@ -35,10 +41,10 @@ uvx agentic-hil --version
 3. If the PyPI package lookup fails, use the repository as the package source (this is a package source only — it does not create a checkout):
 
 ```bash
-uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version
+uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
-4. If `uv` is missing but `pipx` is available, the equivalents are `pipx run agentic-hil --version` and `pipx run --spec git+https://github.com/agentic-hil/agentic-hil agentic-hil --version`.
+4. If `uv` is missing but `pipx` is available, the equivalents are `pipx run agentic-hil --version` and `pipx run --spec git+https://github.com/hp-8472/agentic-hil agentic-hil --version`.
 5. If neither `uv` nor `pipx` is available, install `uv` user-locally (no admin rights; installs to `~/.local/bin`):
 
 ```bash
@@ -50,7 +56,7 @@ then rerun step 2. A missing runner is a remediable setup prerequisite, not a re
 For the MCP server entry it is usually better to install the `agentic-hil` command persistently (still user-local, still no admin rights):
 
 ```bash
-uv tool install agentic-hil        # or from the repository: uv tool install git+https://github.com/agentic-hil/agentic-hil
+uv tool install agentic-hil        # or from the repository: uv tool install git+https://github.com/hp-8472/agentic-hil
 ```
 
 `pipx install agentic-hil` is the equivalent. Both place `agentic-hil` into `~/.local/bin`; if that is not on `PATH`, fix it with `uv tool update-shell` or `pipx ensurepath` — never with admin rights.

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -7,7 +7,7 @@ This file is for agents. Humans should start with `README.md` and use `TROUBLESH
 Canonical copy/paste user request:
 
 ```text
-Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.
+Install from https://github.com/hp-8472/agentic-hil and set it up for this project.
 ```
 
 If you were given only the Agentic HIL repository URL and asked to set it up: run the fast path below, install the Agentic HIL skill into your own skill directory, configure the firmware project, then return to the firmware project. Do not clone, checkout, or vendor the Agentic HIL source tree into the firmware project for normal setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to HardCI will be documented in this file.
+All notable changes to Agentic HIL will be documented in this file.
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
@@ -12,6 +12,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ### Changed
 
+- Public project URLs, setup docs, issue templates, and CLI guidance now point at `hp-8472/agentic-hil` and `agentic-hil`.
 - Firmware flashing no longer resets the target by default. Pass `reset_after_flash: true` to `hardci_flash_firmware` to request the previous post-flash reset behavior.
 - Removed the separate `permissions.allow_reset` policy field; reset remains a typed debugger action instead of a separately gated permission class.
 
@@ -35,8 +36,8 @@ First public release on PyPI.
 - MCP stdio server exposing 35 bounded tools for probing, flashing, resetting, artifact validation, serial and CAN stimuli/feedback, structured reports, and error classification, gated by a project-local `.hardci/config.yaml` policy.
 - OpenOCD and STM32CubeProgrammer CLI (`stlink`) debugger backends with success-marker confirmation, structured error classification, and per-action logs.
 - Test-adapter layer for sensor/actuator/fault simulation: an `adapters:` config section with channel and fault allowlists enforced before anything reaches the adapter, seven `hardci_adapter_*` MCP tools, a JSON-over-stdio bridge protocol for physical adapters and simulators, and a bundled NTC simulator (`examples/adapters/sim_ntc_adapter.py`).
-- pytest plugin: installing `hardci` registers the session-scoped `hardci` fixture that drives the same policy-gated tools in CI regression suites, with per-test stimulus-session cleanup, rootdir-anchored config resolution, and skip-when-absent / fail-when-invalid config semantics.
+- pytest plugin: installing `agentic-hil` registers the session-scoped `agentic_hil` fixture that drives the same policy-gated tools in CI regression suites, with per-test stimulus-session cleanup, rootdir-anchored config resolution, and skip-when-absent / fail-when-invalid config semantics.
 - CLI commands: `init`, `doctor`, `com-ports`, `mcp-stdio`, `com-stdio`, `schema`, `mcp-config`, and `skill-install` for opencode, Claude Code, and Codex.
-- Agent-first, no-admin installation flow: `AI_AGENT_QUICKSTART.md`, `llms.txt`, and `TROUBLESHOOTING.md`, built around `uvx hardci` / `pipx run hardci` with a repository-URL fallback.
+- Agent-first, no-admin installation flow: `AI_AGENT_QUICKSTART.md`, `llms.txt`, and `TROUBLESHOOTING.md`, built around `uvx agentic-hil` / `pipx run agentic-hil` with a repository-URL fallback.
 - Nucleo-F446RE demo firmware (`examples/nucleo-f446re_demo/`) exercising the complete loop on real hardware: build → flash → reset → assert on the UART boot banner.
 - PyPI trusted publishing with a release-tag/package-version guard and digital attestations; CI matrix across Linux/macOS/Windows and Python 3.10–3.13 with ruff linting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Good first contributions are usually docs, examples, setup diagnostics, error-me
 
 Use the bug report issue template when possible. Include enough information for someone else to reproduce the setup without guessing:
 
-- HardCI version (`hardci --version`) and installation method (uv, pipx, pip, source).
+- Agentic HIL version (`agentic-hil --version`) and installation method (uv, pipx, pip, source).
 - Host OS, Python version, and OpenOCD or STM32CubeProgrammer version.
 - Board, debug probe, debugger backend, and serial/CAN/adapter hardware if relevant.
 - Minimal command sequence that triggered the failure.
@@ -40,7 +40,7 @@ Use the bug report issue template when possible. Include enough information for 
 - Sanitized `.hardci/config.yaml` with local paths, usernames, and secrets removed.
 - Relevant `.hardci/reports/last-report.json` content.
 - Relevant debugger, COM, CAN, or adapter `log_path` output, sanitized if needed.
-- Whether the failure is reproducible after reconnecting the board and rerunning `hardci doctor`.
+- Whether the failure is reproducible after reconnecting the board and rerunning `agentic-hil doctor`.
 
 ## Hardware Safety
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Every hardware action is validated against the project policy, executed with tim
 
 ## Install
 
-The easiest path: tell your AI agent
+The easiest path: copy/paste this prompt to your AI agent:
 
-> Install Agentic HIL and set it up for this project.
+```text
+Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.
+```
 
 Agents follow [AI_AGENT_QUICKSTART.md](AI_AGENT_QUICKSTART.md) — everything installs user-local, **no admin rights required, ever**.
 
@@ -40,7 +42,7 @@ By hand, without installing anything (no `PATH` changes; needs [uv](https://docs
 
 ```bash
 uvx agentic-hil --version
-uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version
+uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
 Persistent user-local install (recommended for the MCP server entry):

--- a/README.md
+++ b/README.md
@@ -14,26 +14,12 @@ Agentic HIL is a Python package that exposes bounded MCP tools for probing, flas
 
 HardCI adapters are the reference hardware for Agentic HIL: physical pytest fixtures for sensor simulation, loads, and fault injection.
 
-## Why
-
-A green build is not enough in embedded development: firmware has to behave correctly on the real board. Classic tools automate single steps — flash here, read a log there — but the moment real hardware has to respond, a human is back in the loop. Handing an agent a raw debugger shell or direct serial access instead is neither safe nor reproducible. Agentic HIL closes the gap with a small, auditable gate:
-
-```
-AI agent / CI  ──MCP (stdio)──▶  Agentic HIL  ──policy check──▶  OpenOCD / pyOCD / STM32CubeProgrammer
-                                    │                        serial ports (pyserial)
-                                    │                        CAN (PEAK / SocketCAN / bridge)
-                                    ▼
-                       structured results, reports, logs
-```
-
-Every hardware action is validated against the project policy, executed with timeouts, logged to `.hardci/logs/`, and answered with a structured JSON result (`ok`, `error_type`, `summary`, `likely_causes`, `report_path`, `log_path`) that an agent can act on.
-
 ## Install
 
 The easiest path: copy/paste this prompt to your AI agent:
 
 ```text
-Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.
+Install from https://github.com/hp-8472/agentic-hil and set it up for this project.
 ```
 
 Agents follow [AI_AGENT_QUICKSTART.md](AI_AGENT_QUICKSTART.md) — everything installs user-local, **no admin rights required, ever**.
@@ -55,6 +41,20 @@ agentic-hil mcp-config --output .mcp.json
 ```
 
 For direct PEAK/SocketCAN access install the CAN extra: `uv tool install 'agentic-hil[can]'`. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when something does not start.
+
+## Why
+
+A green build is not enough in embedded development: firmware has to behave correctly on the real board. Classic tools automate single steps — flash here, read a log there — but the moment real hardware has to respond, a human is back in the loop. Handing an agent a raw debugger shell or direct serial access instead is neither safe nor reproducible. Agentic HIL closes the gap with a small, auditable gate:
+
+```
+AI agent / CI  ──MCP (stdio)──▶  Agentic HIL  ──policy check──▶  OpenOCD / pyOCD / STM32CubeProgrammer
+                                    │                        serial ports (pyserial)
+                                    │                        CAN (PEAK / SocketCAN / bridge)
+                                    ▼
+                       structured results, reports, logs
+```
+
+Every hardware action is validated against the project policy, executed with timeouts, logged to `.hardci/logs/`, and answered with a structured JSON result (`ok`, `error_type`, `summary`, `likely_causes`, `report_path`, `log_path`) that an agent can act on.
 
 ## MCP Entry
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-This page covers the most common HardCI setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Python 3.10 or newer.
+This page covers the most common Agentic HIL setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Python 3.10 or newer.
 
 Always inspect structured JSON first. The most useful fields are `ok`, `error_type`, `backend_error_type`, `summary`, `likely_causes`, `report_path`, and `log_path`.
 
@@ -8,43 +8,43 @@ Always inspect structured JSON first. The most useful fields are `ok`, `error_ty
 
 - If OpenOCD is installed but not on `PATH`, set `debugger.executable` explicitly, for example `C:/Program Files/OpenOCD/bin/openocd.exe`.
 - Use forward slashes in YAML paths to avoid accidental escape sequences.
-- Run `hardci com-ports` after reconnecting USB serial hardware.
+- Run `agentic-hil com-ports` after reconnecting USB serial hardware.
 - Configure Windows COM devices such as `COM5` under named `com_ports` ids, then use those ids from MCP COM tools.
 - Configure PEAK CAN devices under named `can_buses` ids, for example `adapter: "peak"` and `channel: "PCAN_USBBUS1"` on Windows.
 
-## 1. `hardci` Command Not Found
+## 1. `agentic-hil` Command Not Found
 
 Symptom: the shell or MCP client cannot start HardCI.
 
-Likely cause: HardCI is not installed, `~/.local/bin` is not on `PATH`, or the MCP client starts with a minimal environment.
+Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or the MCP client starts with a minimal environment.
 
 Fix — all user-local, never with admin rights:
 
 ```bash
-uvx hardci --version                                          # run without installing
-uvx --from git+https://github.com/hp-8472/hardci hardci --version   # repository as package source
-uv tool install hardci                                        # persistent user-local install
+uvx agentic-hil --version                                                # run without installing
+uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version   # repository as package source
+uv tool install agentic-hil                                              # persistent user-local install
 ```
 
-`pipx run hardci` / `pipx install hardci` are equivalents. If `hardci` is installed but not found, add `~/.local/bin` to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run agentic-hil` / `pipx install agentic-hil` are equivalents. If `agentic-hil` is installed but not found, add `~/.local/bin` to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
-In `.mcp.json`, a runner form avoids the `PATH` question entirely: `"command": "uvx", "args": ["hardci", "mcp-stdio", "--config", ".hardci/config.yaml"]`.
+In `.mcp.json`, a runner form avoids the `PATH` question entirely: `"command": "uvx", "args": ["agentic-hil", "mcp-stdio", "--config", ".hardci/config.yaml"]`.
 
 ## 2. `config_file_not_found` / `config_invalid` / `config_unreadable`
 
-Symptom: `hardci doctor` returns one of these `error_type` values.
+Symptom: `agentic-hil doctor` returns one of these `error_type` values.
 
 Likely cause: `.hardci/config.yaml` is missing, the command runs from the wrong directory, the YAML is invalid or not UTF-8, or the file contains an unknown field or unsupported value.
 
-Fix: run `hardci init` from the firmware project directory, edit only project-specific fields, then run `hardci doctor` again. Use the structured fields such as `field`, `allowed_fields`, `allowed_values`, and `expected_type` to fix schema errors.
+Fix: run `agentic-hil init` from the firmware project directory, edit only project-specific fields, then run `agentic-hil doctor` again. Use the structured fields such as `field`, `allowed_fields`, `allowed_values`, and `expected_type` to fix schema errors.
 
 ## 3. `debugger_not_found`
 
-Symptom: `hardci doctor` returns `ok: false` with `error_type: "debugger_not_found"`.
+Symptom: `agentic-hil doctor` returns `ok: false` with `error_type: "debugger_not_found"`.
 
 Likely cause: OpenOCD (or pyOCD for `type: "pyocd"`, or STM32CubeProgrammer CLI for `type: "stlink"`) is not installed, not on `PATH`, or `debugger.executable` points to a missing file.
 
-Fix: install the debugger tool (`pyocd` comes with the `hardci[pyocd]` extra), restart the shell or MCP client, and either leave `debugger.executable: null` or set it to the actual executable path. For pyOCD targets beyond the built-ins, install the CMSIS pack first (`pyocd pack install <target_type>`).
+Fix: install the debugger tool (`pyocd` comes with the `agentic-hil[pyocd]` extra), restart the shell or MCP client, and either leave `debugger.executable: null` or set it to the actual executable path. For pyOCD targets beyond the built-ins, install the CMSIS pack first (`pyocd pack install <target_type>`).
 
 ## 4. `debugger_config_not_found`
 
@@ -60,7 +60,7 @@ Symptom: OpenOCD starts but HardCI reports `error_type: "adapter_not_found"`.
 
 Likely cause: the debug probe is not connected, the USB cable is charge-only, a driver/udev rule is missing, or another process owns the probe.
 
-Fix: reconnect with a data-capable USB cable, close other debugger sessions, check OS drivers or udev rules, then run `hardci doctor` and probe again.
+Fix: reconnect with a data-capable USB cable, close other debugger sessions, check OS drivers or udev rules, then run `agentic-hil doctor` and probe again.
 
 ## 6. `target_not_detected`
 
@@ -100,7 +100,7 @@ Symptom: COM tools cannot start a session, return permission errors, or read no 
 
 Likely cause: the port is not configured under `com_ports`, the device name is wrong, the baud rate is wrong, another program owns the port, or serial access permissions are missing.
 
-Fix: run `hardci com-ports`, add only the approved project port to `.hardci/config.yaml`, close other serial monitors, and use MCP COM tools with the configured `port_id`.
+Fix: run `agentic-hil com-ports`, add only the approved project port to `.hardci/config.yaml`, close other serial monitors, and use MCP COM tools with the configured `port_id`.
 
 Linux permission note: if opening the device fails with a permission error, the user typically needs membership in the `dialout` (Debian/Ubuntu) or `uucp` (Arch) group, or a udev rule for the adapter. This is the one setup step that may genuinely need an administrator once; HardCI itself never needs admin rights.
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -1,6 +1,6 @@
 # Release Strategy
 
-HardCI publishes through PyPI and GitHub Releases. GitHub Releases trigger publishing and carry release notes; PyPI is the canonical installation channel (`uvx hardci`, `uv tool install hardci`, `pipx install hardci`).
+Agentic HIL publishes through PyPI and GitHub Releases. GitHub Releases trigger publishing and carry release notes; PyPI is the canonical installation channel (`uvx agentic-hil`, `uv tool install agentic-hil`, `pipx install agentic-hil`).
 
 Do not cut the next release for metadata-only or README-only cleanup. Batch hygiene work into the next release that delivers visible user value.
 
@@ -44,13 +44,13 @@ Before creating a release:
 1. Update pyproject.toml version and CHANGELOG.md together.
 2. Run ruff check src tests examples and pytest.
 3. Run python -m build (or uv build) and inspect the packaged files.
-4. Merge to main and let the CI matrix pass.
+4. Merge to master and let the CI matrix pass.
 5. Create a GitHub Release with a strict SemVer vX.Y.Z tag that exactly matches pyproject.toml.
 6. Let the publish workflow validate the tag, build, check, and publish to PyPI.
-7. Verify: uvx hardci --version resolves the new version from PyPI.
+7. Verify: uvx agentic-hil --version resolves the new version from PyPI.
 8. Start from GitHub auto-generated release notes, then edit for clarity.
 ```
 
 ## Repository Protection
 
-Keep `main` protected with required status checks (`Required CI`). Pull requests from agent-driven development are reviewed and approved by the repository owner, so a required approval count of 1 works even with a single human maintainer. Block force pushes and branch deletion. Dismiss stale approvals when new commits are pushed.
+Keep `master` protected with required status checks (`Required CI`). Pull requests from agent-driven development are reviewed and approved by the repository owner, so a required approval count of 1 works even with a single human maintainer. Block force pushes and branch deletion. Dismiss stale approvals when new commits are pushed.

--- a/docs/repository-security.md
+++ b/docs/repository-security.md
@@ -18,7 +18,7 @@ Recommended additions as the project grows:
 
 Branch protection is configured in GitHub repository settings, not in this source tree.
 
-Use these settings for `main`:
+Use these settings for the default branch, `master`:
 
 ```text
 require pull requests before merging

--- a/docs/security-design.md
+++ b/docs/security-design.md
@@ -1,10 +1,10 @@
 # Security Design
 
-HardCI is a local MCP stdio server for agent-driven embedded hardware workflows. Its security design focuses on keeping host and hardware actions explicit, narrow, configured, and auditable.
+Agentic HIL is a local MCP stdio server for agent-driven embedded hardware workflows. Its security design focuses on keeping host and hardware actions explicit, narrow, configured, and auditable.
 
 ## Threat Model
 
-HardCI assumes an agent can request hardware actions, but should not receive arbitrary host shell access, arbitrary debugger access, or unrestricted device access through HardCI. The project-local `.hardci/config.yaml` file is the authority for target configuration, artifact roots, named COM ports, CAN buses, test adapters, and permissions. Whoever can edit that file controls the gate — protect it like CI configuration.
+Agentic HIL assumes an agent can request hardware actions, but should not receive arbitrary host shell access, arbitrary debugger access, or unrestricted device access through Agentic HIL. The project-local `.hardci/config.yaml` file is the authority for target configuration, artifact roots, named COM ports, CAN buses, test adapters, and permissions. Whoever can edit that file controls the gate — protect it like CI configuration.
 
 The primary risks are:
 
@@ -20,7 +20,7 @@ The primary risks are:
 - MCP tools expose named, high-level actions — probe, flash, reset, report retrieval, configured COM/CAN sessions, and configured test-adapter actions — instead of a raw debugger shell or direct host device access.
 - Firmware artifacts must be under configured artifact roots, match configured extensions, and pass format plausibility checks before flashing or upload resolution; path traversal is rejected.
 - Uploaded artifacts are size-limited and identified with SHA-256 metadata.
-- COM, CAN, and adapter access use configured `port_id`/`bus_id`/`adapter_id` values. HardCI never opens host devices or executables from agent-provided paths.
+- COM, CAN, and adapter access use configured `port_id`/`bus_id`/`adapter_id` values. Agentic HIL never opens host devices or executables from agent-provided paths.
 - Test-adapter channel and fault names are explicit allowlists validated before any request reaches the adapter bridge.
 - Serial/CAN writes are size-capped; reads are buffer-capped; debugger calls run with timeouts and with OpenOCD's TCP servers disabled.
 - Flashing is refused while `allow_raw_debugger_commands` or `allow_mass_erase` is enabled — validated flashing and unrestricted debugger access are mutually exclusive policies.
@@ -29,7 +29,7 @@ The primary risks are:
 
 ## Cryptography Scope
 
-HardCI does not implement authentication, password storage, encryption protocols, key agreement, or custom cryptographic primitives. It uses the Python standard library (`hashlib`) for SHA-256 artifact metadata. Release integrity is handled by PyPI delivery over HTTPS, GitHub Actions OIDC trusted publishing, and GitHub artifact attestations.
+Agentic HIL does not implement authentication, password storage, encryption protocols, key agreement, or custom cryptographic primitives. It uses the Python standard library (`hashlib`) for SHA-256 artifact metadata. Release integrity is handled by PyPI delivery over HTTPS, GitHub Actions OIDC trusted publishing, and GitHub artifact attestations.
 
 ## Secure Development Practices
 

--- a/examples/nucleo-f446re_demo/README.md
+++ b/examples/nucleo-f446re_demo/README.md
@@ -17,15 +17,15 @@ cmake --preset Debug
 cmake --build --preset Debug
 ```
 
-This produces `build/Debug/nucleo-f446re_demo.elf` (plus `.hex`/`.bin`) — inside the `build` artifact root that the HardCI policy allows for flashing.
+This produces `build/Debug/nucleo-f446re_demo.elf` (plus `.hex`/`.bin`) — inside the `build` artifact root that the Agentic HIL policy allows for flashing.
 
-## Configure HardCI
+## Configure Agentic HIL
 
 ```bash
-pipx install hardci
+pipx install agentic-hil
 mkdir -p .hardci && cp hardci.config.example.yaml .hardci/config.yaml
 # adjust com_ports.dut_uart.device (e.g. /dev/ttyACM0, COM5), then:
-hardci doctor
+agentic-hil doctor
 ```
 
 ## Run the loop from an agent (MCP)

--- a/examples/pytest/test_ntc_diagnosis.py
+++ b/examples/pytest/test_ntc_diagnosis.py
@@ -1,14 +1,14 @@
-"""Example: temperature-sensor diagnosis loop driven by the HardCI pytest plugin.
+"""Example: temperature-sensor diagnosis loop driven by the Agentic HIL pytest plugin.
 
-Run from a checkout of the hardci repository (or copy this file together with
+Run from a checkout of the agentic-hil repository (or copy this file together with
 examples/adapters/sim_ntc_adapter.py into your firmware project) with a
 .hardci/config.yaml whose adapters section points at the simulator, as shown
 in examples/adapters/README.md:
 
-    pip install hardci
+    pip install agentic-hil
     pytest test_ntc_diagnosis.py
 
-The `hardci` fixture skips these tests when no HardCI configuration file
+The `agentic_hil` fixture skips these tests when no Agentic HIL configuration file
 exists, so the suite stays green in code-only environments, and it stops
 adapter sessions after each test so fault state cannot leak between tests.
 
@@ -25,10 +25,10 @@ ADAPTER_ID = "ntc_sim"
 
 
 @pytest.fixture()
-def ntc(hardci):
-    started = hardci.call("hardci_adapter_session_start", {"adapter_id": ADAPTER_ID})
+def ntc(agentic_hil):
+    started = agentic_hil.call("hardci_adapter_session_start", {"adapter_id": ADAPTER_ID})
     assert started["ok"] is True, started["summary"]
-    return hardci  # the plugin stops adapter sessions after each test
+    return agentic_hil  # the plugin stops adapter sessions after each test
 
 
 def test_nominal_temperature_reading(ntc) -> None:

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 Agentic HIL is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection. HardCI adapters are the reference hardware.
 
-Canonical setup request: `Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.`
+Canonical setup request: `Install from https://github.com/hp-8472/agentic-hil and set it up for this project.`
 
 Run without installing (no admin rights, no PATH changes):
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,22 +1,24 @@
-# HardCI
+# Agentic HIL
 
-HardCI is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection.
+Agentic HIL is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection. HardCI adapters are the reference hardware.
+
+Canonical setup request: `Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.`
 
 Run without installing (no admin rights, no PATH changes):
 
 ```bash
-uvx hardci --version
-uvx --from git+https://github.com/hp-8472/hardci hardci --version
+uvx agentic-hil --version
+uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
-Persistent user-local install: `uv tool install hardci` or `pipx install hardci`. Never sudo, never --break-system-packages. Requires Python 3.10+.
+Persistent user-local install: `uv tool install agentic-hil` or `pipx install agentic-hil`. Never sudo, never --break-system-packages. Requires Python 3.10+.
 
 Bootstrap each firmware project from the project directory:
 
 ```bash
-hardci init
-hardci doctor
-hardci mcp-config --output .mcp.json
+agentic-hil init
+agentic-hil doctor
+agentic-hil mcp-config --output .mcp.json
 ```
 
 Each firmware project keeps its own `.hardci/config.yaml` — the policy for that project's target, debugger, permissions, artifact roots, com_ports, can_buses, and adapters.
@@ -24,7 +26,7 @@ Each firmware project keeps its own `.hardci/config.yaml` — the policy for tha
 MCP stdio command:
 
 ```text
-hardci mcp-stdio --config .hardci/config.yaml
+agentic-hil mcp-stdio --config .hardci/config.yaml
 ```
 
 Use MCP tools for hardware actions:
@@ -47,7 +49,7 @@ Required workflow:
 4. Stimulate via com/can/adapter tools, assert on feedback.
 5. Read the structured result and last report; classify failures before changing code again.
 
-pytest: installing hardci registers a plugin; the `hardci` fixture drives the same tools in CI regression suites.
+pytest: installing `agentic-hil` registers a plugin; the `agentic_hil` fixture drives the same tools in CI regression suites.
 
 Safety: do not request raw OpenOCD commands, do not open host serial/CAN/adapter devices directly, do not flash outside allowed artifact roots. Treat `permission_denied` as authoritative.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/agentic-hil/agentic-hil"
-Repository = "https://github.com/agentic-hil/agentic-hil.git"
-Issues = "https://github.com/agentic-hil/agentic-hil/issues"
+Homepage = "https://github.com/hp-8472/agentic-hil"
+Repository = "https://github.com/hp-8472/agentic-hil.git"
+Issues = "https://github.com/hp-8472/agentic-hil/issues"
 
 [project.scripts]
 agentic-hil = "agentic_hil.cli:entrypoint"

--- a/src/hardci/cli.py
+++ b/src/hardci/cli.py
@@ -213,14 +213,14 @@ def init_next_steps(available_com_ports: JsonObject) -> list[str]:
             suffix = "" if len(ports) <= 5 else f", and {len(ports) - 5} more"
             next_steps.append(f"Detected COM ports: {devices}{suffix}. Add the DUT UART under com_ports if serial feedback is needed.")
         else:
-            next_steps.append("No host COM ports detected. Connect USB serial hardware and run: hardci com-ports")
+            next_steps.append("No host COM ports detected. Connect USB serial hardware and run: agentic-hil com-ports")
     else:
-        next_steps.append("COM port discovery failed. Run: hardci com-ports after checking the pyserial installation.")
+        next_steps.append("COM port discovery failed. Run: agentic-hil com-ports after checking the pyserial installation.")
     next_steps.extend(
         [
             "For CAN access, add a named bus under can_buses.",
             "For sensor/actuator/fault simulation, add a named test adapter under adapters.",
-            "Run: hardci doctor",
+            "Run: agentic-hil doctor",
             "Create or update .mcp.json if your MCP client needs project discovery.",
         ]
     )
@@ -359,12 +359,12 @@ def skill_install_root(target_path: str) -> str:
 
 def codex_registration_block(target_path: str, version: str, requested_agent: str) -> str:
     return f"""{HARDCI_REGISTRATION_START}
-## HardCI Skill
+## Agentic HIL Skill
 
 - Skill path: `{target_path}`
-- HardCI version: `{version}`
-- HardCI is for embedded firmware development with local hardware-in-the-loop targets.
-- For HardCI setup, configuration, MCP, or embedded hardware workflows, read and follow this skill before acting.
+- Agentic HIL version: `{version}`
+- Agentic HIL is for embedded firmware development with local hardware-in-the-loop targets.
+- For Agentic HIL setup, configuration, MCP, or embedded hardware workflows, read and follow this skill before acting.
 - If this version differs from `agentic-hil --version`, run `agentic-hil skill-install --agent {requested_agent}`.
 {HARDCI_REGISTRATION_END}"""
 

--- a/src/hardci/skills/hardci-config-setup/SKILL.md
+++ b/src/hardci/skills/hardci-config-setup/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: hardci-config-setup
-description: Configure HardCI as the safe local hardware-in-the-loop MCP bridge for an embedded firmware project.
+description: Configure Agentic HIL as the safe local hardware-in-the-loop MCP bridge for an embedded firmware project.
 metadata:
   origin: HardCI
-  hardci_version: "0.1.0"
+  hardci_version: "0.2.0"
 ---
 
-# HardCI Config Setup
+# Agentic HIL Config Setup
 
-Use HardCI as the project-local hardware gate. The policy file is `.hardci/config.yaml`.
+Use Agentic HIL as the project-local hardware gate. The policy file is `.hardci/config.yaml`.
 
 Install and initialize from the firmware project directory:
 
 ```bash
-hardci init
-hardci doctor
+agentic-hil init
+agentic-hil doctor
 ```
 
-Never bypass HardCI policy with raw debugger commands, direct serial device access, or direct CAN adapter access when a HardCI MCP tool is available.
+Never bypass Agentic HIL policy with raw debugger commands, direct serial device access, or direct CAN adapter access when an Agentic HIL MCP tool is available.
 
-If any HardCI tool returns `permission_denied`, stop and ask the user before changing policy.
+If any Agentic HIL tool returns `permission_denied`, stop and ask the user before changing policy.


### PR DESCRIPTION
Summary:
- Update public project URLs to hp-8472/agentic-hil for future PyPI metadata.
- Make the canonical setup request copyable: Install Agentic HIL from https://github.com/hp-8472/agentic-hil and set it up for this project.
- Align docs, issue templates, workflow branch triggers, CLI guidance, examples, and bundled setup skill with agentic-hil.

Validation:
- uv run --extra dev ruff check src tests examples
- uv run --extra dev pytest
- uv run --extra dev python -m build; uv run --extra dev twine check dist/*