### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,27 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-### Added
-
-- Debug sessions now classify abnormal target stops: unexpected breakpoints return `unexpected_breakpoint`, Cortex-M exception/fault contexts return `target_exception` with frame, signal, and suggested next actions, and session status picks up asynchronous stop records.
+## [0.2.1] - 2026-07-09
 
 ### Changed
 
-- Public project URLs and CLI/MCP guidance now point at `hp-8472/agentic-hil` and `agentic-hil`; Python package install guidance uses `agentic_hil`.
-- Firmware flashing no longer resets the target by default. Pass `reset_after_flash: true` to `hardci_flash_firmware` to request the previous post-flash reset behavior.
-- Removed the separate `permissions.allow_reset` policy field; reset remains a typed debugger action instead of a separately gated permission class.
+- Python package metadata and install guidance now use `agentic_hil`; the CLI command, MCP server name, and repository URL remain `agentic-hil`.
+- Public project URLs, setup docs, issue templates, and release guidance now point at `hp-8472/agentic-hil`.
+- CLI setup hints and Codex skill-registration text use Agentic HIL naming instead of legacy HardCI command/prose.
+- CI, CodeQL, and Scorecards workflows now run for the `master` default branch.
 
 ## [0.2.0] - 2026-07-06
 
 ### Added
 
+- Debug sessions now classify abnormal target stops: unexpected breakpoints return `unexpected_breakpoint`, Cortex-M exception/fault contexts return `target_exception` with frame, signal, and suggested next actions, and session status picks up asynchronous stop records.
 - Typed GDB/MI debug sessions for the OpenOCD backend: the eleven `hardci_debug_*` tools now run real sessions (start/stop/status, breakpoints by symbol or file:line, continue/halt with structured stop reasons, symbol resolution, Intel-HEX memory dumps) against OpenOCD's gdbserver, gated by `debug.allowed_symbols`, `debug.max_dump_size_bytes`, and the existing permission model (raw-command mode disables typed debugging; `load` mode requires flash permission). The session's gdbserver is pinned to `localhost` on an ephemeral port and torn down with the session.
 - pyOCD debugger backend (`debugger.type: "pyocd"`) with probe/flash/reset support, `target_type` selection, and pyOCD-specific error classification.
+
+### Changed
+
+- Firmware flashing no longer resets the target by default. Pass `reset_after_flash: true` to `hardci_flash_firmware` to request the previous post-flash reset behavior.
+- Removed the separate `permissions.allow_reset` policy field; reset remains a typed debugger action instead of a separately gated permission class.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic_hil"
-version = "0.2.0"
+version = "0.2.1"
 description = "Agentic hardware-in-the-loop tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/hardci/__init__.py
+++ b/src/hardci/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 if TYPE_CHECKING:
     from hardci.artifacts import ArtifactManager

--- a/src/hardci/skills/hardci-config-setup/SKILL.md
+++ b/src/hardci/skills/hardci-config-setup/SKILL.md
@@ -3,7 +3,7 @@ name: hardci-config-setup
 description: Configure Agentic HIL as the safe local hardware-in-the-loop MCP bridge for an embedded firmware project.
 metadata:
   origin: HardCI
-  hardci_version: "0.2.0"
+  hardci_version: "0.2.1"
 ---
 
 # Agentic HIL Config Setup


### PR DESCRIPTION
Summary:
- bump package, CLI, and bundled skill version to 0.2.1
- add v0.2.1 changelog entries for install naming, public URLs, CLI text, and master-branch CI coverage
- move already-released v0.2.0 debug/reset notes into the v0.2.0 changelog section

Verification:
- uv run ruff check src tests examples
- uv run pytest
- uv build
- uv run agentic-hil --version
- pyproject version check returned 0.2.1
- uv run twine check dist/*