### PR TITLE
chore: release Agentic HIL v0.2.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible Agentic HIL setup, hardware, CLI, MCP, or COM failure.
+description: Report a reproducible Agentic Hardware-in-the-Loop (Agentic HIL) setup, hardware, CLI, MCP, or COM failure.
 title: "bug: "
 labels:
   - bug
@@ -21,9 +21,9 @@ body:
     attributes:
       label: Installation method
       options:
-        - pip install agentic_hil
-        - pipx install agentic_hil
-        - uv tool install agentic_hil
+        - pip install agentic-hil
+        - pipx install agentic-hil
+        - uv tool install agentic-hil
         - pip install from git checkout
         - other
     validations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # Agentic HIL Agent Instructions
 
-Agentic HIL is the hardware gate. The project-local `.agentic-hil/config.yaml` is the policy. Agentic HIL adapters are the reference hardware.
+Agentic Hardware-in-the-Loop (Agentic HIL) is the hardware gate. The project-local `.agentic-hil/config.yaml` is the policy. HardCI adapters are the reference hardware.
 
 For installation and first-time setup, follow [AI_AGENT_QUICKSTART.md](AI_AGENT_QUICKSTART.md) — everything installs user-local without admin rights.
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 Use Agentic HIL MCP tools for hardware actions. Do not bypass them with raw OpenOCD commands, arbitrary debugger shells, direct serial-device access, direct CAN-adapter access, or direct test-adapter access when an Agentic HIL tool is available.
 
-If a Agentic HIL tool returns `permission_denied`, stop. Do not loosen policy unless the user explicitly asks.
+If an Agentic HIL tool returns `permission_denied`, stop. Do not loosen policy unless the user explicitly asks.
 
 Install or update the local agent setup skill with:
 

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -1,6 +1,6 @@
 # AI Agent Quickstart
 
-Use Agentic HIL as the local MCP server for embedded firmware development and embedded hardware actions. Agentic HIL adapters are the reference hardware.
+Use Agentic Hardware-in-the-Loop (Agentic HIL) as the local MCP server for embedded firmware development and embedded hardware actions. HardCI adapters are the reference hardware.
 
 This file is for agents. Humans should start with `README.md` and use `TROUBLESHOOTING.md` for operator-facing diagnostics.
 
@@ -16,7 +16,7 @@ If you were given only the Agentic HIL repository URL and asked to set it up: ru
 
 - Never use `sudo` or any administrator privileges for the Agentic HIL installation. Every step below works user-local.
 - Never use `pip install --break-system-packages`, and do not install into the system Python (PEP 668 environments will refuse, and they are right).
-- Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+- Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 - If the board, debugger, COM port, or artifact path cannot be inferred, ask one concise question instead of guessing.
 
 ## Reference Setup
@@ -36,7 +36,7 @@ Fast path, in order — stop at the first step that works:
 2. Try the normal user-local pip install first:
 
 ```bash
-python -m pip install --user agentic_hil
+python -m pip install --user agentic-hil
 agentic-hil --version
 ```
 
@@ -45,7 +45,7 @@ If that fails because Python is externally managed, `agentic-hil` is not on `PAT
 3. If `uv` is available, run Agentic HIL without installing anything (no admin rights, no `PATH` changes):
 
 ```bash
-uvx --from agentic_hil agentic-hil --version
+uvx --from agentic-hil agentic-hil --version
 ```
 
 4. If the PyPI package lookup fails, use the repository as the package source (this is a package source only — it does not create a checkout):
@@ -54,7 +54,7 @@ uvx --from agentic_hil agentic-hil --version
 uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
-5. If `uv` is missing but `pipx` is available, the equivalents are `pipx run --spec agentic_hil agentic-hil --version` and `pipx run --spec git+https://github.com/hp-8472/agentic-hil agentic-hil --version`.
+5. If `uv` is missing but `pipx` is available, the equivalents are `pipx run --spec agentic-hil agentic-hil --version` and `pipx run --spec git+https://github.com/hp-8472/agentic-hil agentic-hil --version`.
 6. If neither `uv` nor `pipx` is available, install `uv` user-locally (no admin rights; installs to `~/.local/bin`):
 
 ```bash
@@ -66,20 +66,20 @@ then rerun step 3. A missing runner is a remediable setup prerequisite, not a re
 If the `pip --user` command is not reliably on `PATH`, use an isolated persistent install for the MCP server entry (still user-local, still no admin rights):
 
 ```bash
-uv tool install agentic_hil        # or from the repository: uv tool install git+https://github.com/hp-8472/agentic-hil
+uv tool install agentic-hil        # or from the repository: uv tool install git+https://github.com/hp-8472/agentic-hil
 ```
 
-`pipx install agentic_hil` is the equivalent. Both place `agentic-hil` into `~/.local/bin`; if that is not on `PATH`, fix it with `uv tool update-shell` or `pipx ensurepath` — never with admin rights.
+`pipx install agentic-hil` is the equivalent. Both place `agentic-hil` into `~/.local/bin`; if that is not on `PATH`, fix it with `uv tool update-shell` or `pipx ensurepath` — never with admin rights.
 
 ## Install Agent Skill
 
 Agent-driven Agentic HIL installation includes installing the bundled `agentic-hil-config-setup` skill into the active agent's user-level skill directory after the CLI is available:
 
 ```bash
-agentic-hil skill-install --agent <agent>          # or: uvx --from agentic_hil agentic-hil skill-install --agent <agent>
+agentic-hil skill-install --agent <agent>          # or: uvx --from agentic-hil agentic-hil skill-install --agent <agent>
 ```
 
-Supported agent names and aliases: `opencode`/`open-code`, `claude-code`/`claude`, `codex`/`codex-cli`/`openai-codex`. For other skill-capable agents use `--agent <name> --target <path>` with that agent's documented user-level skill directory. The installed `agentic_hil` package is authoritative: if the installed skill's front-matter version differs from `agentic-hil --version`, rerun `skill-install`.
+Supported agent names and aliases: `opencode`/`open-code`, `claude-code`/`claude`, `codex`/`codex-cli`/`openai-codex`. For other skill-capable agents use `--agent <name> --target <path>` with that agent's documented user-level skill directory. The installed `agentic-hil` distribution is authoritative: if the installed skill's front-matter version differs from `agentic-hil --version`, rerun `skill-install`.
 
 ## Configure Each Project
 
@@ -112,7 +112,7 @@ Expected healthy `agentic-hil doctor` result: `ok: true`, `summary: "Agentic HIL
 }
 ```
 
-If `agentic-hil` is not on `PATH`, use the runner form instead: `"command": "uvx", "args": ["--from", "agentic_hil", "agentic-hil", "mcp-stdio", "--config", ".agentic-hil/config.yaml"]`.
+If `agentic-hil` is not on `PATH`, use the runner form instead: `"command": "uvx", "args": ["--from", "agentic-hil", "agentic-hil", "mcp-stdio", "--config", ".agentic-hil/config.yaml"]`.
 
 `mcp-stdio` is project-scoped and JSON-RPC only. COM tool calls pass `port_id`, CAN tool calls pass `bus_id`, and test-adapter tool calls pass `adapter_id` as tool arguments. For a continuous plain-text serial channel use a separate `agentic-hil com-stdio --config .agentic-hil/config.yaml --port <port_id>` process — never mix plain text into `mcp-stdio`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-07-14
+## [0.2.2] - 2026-07-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,30 @@
 # Changelog
 
-All notable changes to Agentic HIL will be documented in this file.
+All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be documented in this file.
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-14
+
+### Changed
+
+- Canonicalized the Python distribution metadata spelling and all installation guidance to `agentic-hil`; Python imports, the pytest plugin, and the fixture remain `agentic_hil`.
+- Renamed the CLI, MCP server, policy directory, package modules, examples, and documentation from the historical software name to Agentic HIL.
+- Clarified that HardCI adapters are the reference hardware for Agentic HIL.
+
+### Removed
+
+- Removed the historical `hardci` Python package, CLI, pytest plugin, MCP names, and configuration paths. There is no compatibility alias.
+
 ## [0.2.1] - 2026-07-09
 
 ### Changed
 
-- Python package metadata and install guidance now use `agentic_hil`; the CLI command, MCP server name, and repository URL remain `agentic-hil`.
+- Python package metadata and install guidance were prepared for the Agentic HIL migration; the CLI command, MCP server name, and repository URL use `agentic-hil`.
 - Public project URLs, setup docs, issue templates, and release guidance now point at `hp-8472/agentic-hil`.
-- CLI setup hints and Codex skill-registration text use Agentic HIL naming instead of legacy Agentic HIL command/prose.
+- CLI setup hints and Codex skill-registration text started the migration away from the historical `hardci` command and prose.
 - CI, CodeQL, and Scorecards workflows now run for the `master` default branch.
 
 ## [0.2.0] - 2026-07-06
@@ -20,12 +32,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 ### Added
 
 - Debug sessions now classify abnormal target stops: unexpected breakpoints return `unexpected_breakpoint`, Cortex-M exception/fault contexts return `target_exception` with frame, signal, and suggested next actions, and session status picks up asynchronous stop records.
-- Typed GDB/MI debug sessions for the OpenOCD backend: the eleven `debug_*` tools now run real sessions (start/stop/status, breakpoints by symbol or file:line, continue/halt with structured stop reasons, symbol resolution, Intel-HEX memory dumps) against OpenOCD's gdbserver, gated by `debug.allowed_symbols`, `debug.max_dump_size_bytes`, and the existing permission model (raw-command mode disables typed debugging; `load` mode requires flash permission). The session's gdbserver is pinned to `localhost` on an ephemeral port and torn down with the session.
+- Typed GDB/MI debug sessions for the OpenOCD backend: the eleven `hardci_debug_*` tools now run real sessions (start/stop/status, breakpoints by symbol or file:line, continue/halt with structured stop reasons, symbol resolution, Intel-HEX memory dumps) against OpenOCD's gdbserver, gated by `debug.allowed_symbols`, `debug.max_dump_size_bytes`, and the existing permission model (raw-command mode disables typed debugging; `load` mode requires flash permission). The session's gdbserver is pinned to `localhost` on an ephemeral port and torn down with the session.
 - pyOCD debugger backend (`debugger.type: "pyocd"`) with probe/flash/reset support, `target_type` selection, and pyOCD-specific error classification.
 
 ### Changed
 
-- Firmware flashing no longer resets the target by default. Pass `reset_after_flash: true` to `flash_firmware` to request the previous post-flash reset behavior.
+- Firmware flashing no longer resets the target by default. Pass `reset_after_flash: true` to `hardci_flash_firmware` to request the previous post-flash reset behavior.
 - Removed the separate `permissions.allow_reset` policy field; reset remains a typed debugger action instead of a separately gated permission class.
 
 ### Fixed
@@ -38,11 +50,11 @@ First public release on PyPI.
 
 ### Added
 
-- MCP stdio server exposing 35 bounded tools for probing, flashing, resetting, artifact validation, serial and CAN stimuli/feedback, structured reports, and error classification, gated by a project-local `.agentic-hil/config.yaml` policy.
+- MCP stdio server exposing 35 bounded `hardci_*` tools for probing, flashing, resetting, artifact validation, serial and CAN stimuli/feedback, structured reports, and error classification, gated by a project-local `.hardci/config.yaml` policy.
 - OpenOCD and STM32CubeProgrammer CLI (`stlink`) debugger backends with success-marker confirmation, structured error classification, and per-action logs.
-- Test-adapter layer for sensor/actuator/fault simulation: an `adapters:` config section with channel and fault allowlists enforced before anything reaches the adapter, seven `adapter_*` MCP tools, a JSON-over-stdio bridge protocol for physical adapters and simulators, and a bundled NTC simulator (`examples/adapters/sim_ntc_adapter.py`).
-- pytest plugin: installing `agentic_hil` registers the session-scoped `agentic_hil` fixture that drives the same policy-gated tools in CI regression suites, with per-test stimulus-session cleanup, rootdir-anchored config resolution, and skip-when-absent / fail-when-invalid config semantics.
-- CLI commands: `init`, `doctor`, `com-ports`, `mcp-stdio`, `com-stdio`, `schema`, `mcp-config`, and `skill-install` for opencode, Claude Code, and Codex.
-- Agent-first, no-admin installation flow: `AI_AGENT_QUICKSTART.md`, `llms.txt`, and `TROUBLESHOOTING.md`, built around `agentic_hil` package installs, the `agentic-hil` CLI command, and a repository-URL fallback.
+- Test-adapter layer for sensor/actuator/fault simulation: an `adapters:` config section with channel and fault allowlists enforced before anything reaches the adapter, seven `hardci_adapter_*` MCP tools, a JSON-over-stdio bridge protocol for physical adapters and simulators, and a bundled NTC simulator (`examples/adapters/sim_ntc_adapter.py`).
+- pytest plugin: installing `hardci` registers the session-scoped `hardci` fixture that drives the same policy-gated tools in CI regression suites, with per-test stimulus-session cleanup, rootdir-anchored config resolution, and skip-when-absent / fail-when-invalid config semantics.
+- `hardci` CLI commands: `init`, `doctor`, `com-ports`, `mcp-stdio`, `com-stdio`, `schema`, `mcp-config`, and `skill-install` for opencode, Claude Code, and Codex.
+- Agent-first, no-admin installation flow: `AI_AGENT_QUICKSTART.md`, `llms.txt`, and `TROUBLESHOOTING.md`, built around the historical `hardci` package and CLI plus a repository-URL fallback.
 - Nucleo-F446RE demo firmware (`examples/nucleo-f446re_demo/`) exercising the complete loop on real hardware: build → flash → reset → assert on the UART boot banner.
 - PyPI trusted publishing with a release-tag/package-version guard and digital attestations; CI matrix across Linux/macOS/Windows and Python 3.10–3.13 with ruff linting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Canonical agent instructions live in `AGENTS.md` and `AI_AGENT_QUICKSTART.md`. H
 
 ## Project Overview
 
-Agentic HIL is a Python MCP stdio server for safe embedded firmware development with local hardware-in-the-loop targets. It exposes narrow tools for probing, flashing, resetting, configured COM port stimulus/feedback, configured CAN bus stimulus/feedback, policy-gated test adapters, and reading structured reports from a configured local embedded target.
+Agentic Hardware-in-the-Loop (Agentic HIL) is a Python MCP stdio server for safe embedded firmware development with local hardware-in-the-loop targets. It exposes narrow tools for probing, flashing, resetting, configured COM port stimulus/feedback, configured CAN bus stimulus/feedback, policy-gated test adapters, and reading structured reports from a configured local embedded target.
 
-The project-local `.agentic-hil/config.yaml` file is the policy authority. If a Agentic HIL tool returns `permission_denied`, stop and ask the user instead of loosening policy.
+The project-local `.agentic-hil/config.yaml` file is the policy authority. If an Agentic HIL tool returns `permission_denied`, stop and ask the user instead of loosening policy.
 
 Use STM32 Nucleo-F446RE + ST-Link + OpenOCD + Python 3.10 or newer as the supported first path unless project files or the user clearly identify another setup.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Agentic HIL
 
-Thanks for helping improve Agentic HIL. This project is a local MCP stdio server for safe, structured hardware-in-the-loop access, so changes should keep safety boundaries explicit and easy to audit.
+Thanks for helping improve Agentic Hardware-in-the-Loop (Agentic HIL). This project is a local MCP stdio server for safe, structured hardware-in-the-loop access, so changes should keep safety boundaries explicit and easy to audit.
 
 ## Development Setup
 
@@ -12,7 +12,7 @@ ruff check src tests examples
 pytest
 ```
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic HIL
 
-**Your AI agent can develop firmware on its own — because Agentic HIL closes the loop with real hardware.**
+**Your AI agent can develop firmware on its own — because Agentic Hardware-in-the-Loop (Agentic HIL) closes the loop with real hardware.**
 
 ```
 +--> build --> flash --> stimulate --> observe --+
@@ -12,9 +12,9 @@
 
 Agentic HIL is a Python package that exposes bounded MCP tools for probing, flashing, resetting, artifact validation, serial and CAN stimulus/feedback, test adapters, reports, and logs — without giving an agent arbitrary host or debugger access. A project-local policy file (`.agentic-hil/config.yaml`) defines exactly which devices, actions, paths, and limits are allowed. That policy gate is what makes unattended hardware access workable in the first place.
 
-Agentic HIL adapters are the reference hardware for Agentic HIL: physical pytest fixtures for sensor simulation, loads, and fault injection.
+HardCI adapters are the reference hardware for Agentic HIL: physical pytest fixtures for sensor simulation, loads, and fault injection.
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, MCP server name, and docs prose use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, MCP server name, and docs prose use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 ## Install
 
@@ -29,7 +29,7 @@ Agents follow [AI_AGENT_QUICKSTART.md](AI_AGENT_QUICKSTART.md) — everything in
 If you want to install it yourself anyway, install the Python package with pip and then use the `agentic-hil` command:
 
 ```bash
-pip install agentic_hil
+pip install agentic-hil
 agentic-hil --version
 ```
 
@@ -38,20 +38,20 @@ If that fails because Python is externally managed, `agentic-hil` is not on `PAT
 Without installing anything (no `PATH` changes; needs [uv](https://docs.astral.sh/uv/) or pipx):
 
 ```bash
-uvx --from agentic_hil agentic-hil --version
+uvx --from agentic-hil agentic-hil --version
 uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
 Alternative isolated user-local install (recommended when the MCP client needs a stable command on `PATH`):
 
 ```bash
-uv tool install agentic_hil      # or: pipx install agentic_hil
+uv tool install agentic-hil      # or: pipx install agentic-hil
 agentic-hil init
 agentic-hil doctor
 agentic-hil mcp-config --output .mcp.json
 ```
 
-For direct PEAK/SocketCAN access install the CAN extra: `uv tool install 'agentic_hil[can]'`. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when something does not start.
+For direct PEAK/SocketCAN access install the CAN extra: `uv tool install 'agentic-hil[can]'`. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when something does not start.
 
 ## Why
 
@@ -163,7 +163,7 @@ Example diagnosis loop with the bundled NTC simulator (`examples/adapters/sim_nt
 
 ## pytest Plugin
 
-Installing `agentic_hil` registers the `agentic_hil` pytest plugin, so CI regression suites can drive the same policy-gated tools without an MCP client:
+Installing `agentic-hil` registers the `agentic_hil` pytest plugin, so CI regression suites can drive the same policy-gated tools without an MCP client:
 
 ```python
 def test_open_sensor_diagnosis(agentic_hil):
@@ -191,7 +191,7 @@ agentic-hil skill-install --agent opencode
 
 ## Platform Support
 
-Linux, macOS, and Windows (CI-tested on Python 3.10–3.13). Debugger backends: OpenOCD, pyOCD (`agentic_hil[pyocd]` — covers most ARM Cortex-M targets via CMSIS packs and CMSIS-DAP/ST-Link/J-Link probes, set `debugger.target_type`), and STM32CubeProgrammer CLI (auto-discovered on Windows). Direct CAN requires `agentic_hil[can]` (python-can); any other adapter can be attached through the `process` bridge protocol.
+Linux, macOS, and Windows (CI-tested on Python 3.10–3.13). Debugger backends: OpenOCD, pyOCD (`agentic-hil[pyocd]` — covers most ARM Cortex-M targets via CMSIS packs and CMSIS-DAP/ST-Link/J-Link probes, set `debugger.target_type`), and STM32CubeProgrammer CLI (auto-discovered on Windows). Direct CAN requires `agentic-hil[can]` (python-can); any other adapter can be attached through the `process` bridge protocol.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Agentic HIL's purpose is to be a safe, bounded gate between AI agents and real embedded hardware. Anything that lets an MCP client bypass the project policy in `.agentic-hil/config.yaml` is a security vulnerability, not just a bug. That includes:
+Agentic Hardware-in-the-Loop (Agentic HIL) is a safe, bounded gate between AI agents and real embedded hardware. Anything that lets an MCP client bypass the project policy in `.agentic-hil/config.yaml` is a security vulnerability, not just a bug. That includes:
 
 - flashing or reading artifacts outside `artifacts.allowed_roots`
 - reaching serial devices, CAN channels, or executables that are not named in the config

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-This page covers the most common Agentic HIL setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Python 3.10 or newer.
+This page covers the most common Agentic Hardware-in-the-Loop (Agentic HIL) setup and hardware-loop failures. Start with the supported first path from the README: STM32 Nucleo-F446RE, ST-Link, OpenOCD, and Python 3.10 or newer.
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 Always inspect structured JSON first. The most useful fields are `ok`, `error_type`, `backend_error_type`, `summary`, `likely_causes`, `report_path`, and `log_path`.
 
@@ -23,21 +23,21 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix — all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user agentic_hil
+python -m pip install --user agentic-hil
 agentic-hil --version
 ```
 
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from agentic_hil agentic-hil --version                                  # run without installing
+uvx --from agentic-hil agentic-hil --version                                  # run without installing
 uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version    # repository as package source
-uv tool install agentic_hil                                                    # isolated user-local install
+uv tool install agentic-hil                                                    # isolated user-local install
 ```
 
-`pipx run --spec agentic_hil agentic-hil` / `pipx install agentic_hil` are equivalents. If `agentic-hil` is installed but not found, add `~/.local/bin` to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec agentic-hil agentic-hil` / `pipx install agentic-hil` are equivalents. If `agentic-hil` is installed but not found, add `~/.local/bin` to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
-In `.mcp.json`, a runner form avoids the `PATH` question entirely: `"command": "uvx", "args": ["--from", "agentic_hil", "agentic-hil", "mcp-stdio", "--config", ".agentic-hil/config.yaml"]`.
+In `.mcp.json`, a runner form avoids the `PATH` question entirely: `"command": "uvx", "args": ["--from", "agentic-hil", "agentic-hil", "mcp-stdio", "--config", ".agentic-hil/config.yaml"]`.
 
 ## 2. `config_file_not_found` / `config_invalid` / `config_unreadable`
 
@@ -53,7 +53,7 @@ Symptom: `agentic-hil doctor` returns `ok: false` with `error_type: "debugger_no
 
 Likely cause: OpenOCD (or pyOCD for `type: "pyocd"`, or STM32CubeProgrammer CLI for `type: "stlink"`) is not installed, not on `PATH`, or `debugger.executable` points to a missing file.
 
-Fix: install the debugger tool (`pyocd` comes with the `agentic_hil[pyocd]` extra), restart the shell or MCP client, and either leave `debugger.executable: null` or set it to the actual executable path. For pyOCD targets beyond the built-ins, install the CMSIS pack first (`pyocd pack install <target_type>`).
+Fix: install the debugger tool (`pyocd` comes with the `agentic-hil[pyocd]` extra), restart the shell or MCP client, and either leave `debugger.executable: null` or set it to the actual executable path. For pyOCD targets beyond the built-ins, install the CMSIS pack first (`pyocd pack install <target_type>`).
 
 ## 4. `debugger_config_not_found`
 
@@ -117,7 +117,7 @@ Linux permission note: if opening the device fails with a permission error, the 
 
 Symptom: CAN tools cannot start a session, return `can_bus_not_configured`, `can_backend_not_available`, `config_invalid`, permission errors, or read no expected frames.
 
-Likely cause: the bus is not configured under `can_buses`, the wrong `bus_id` is used, `allow_can_read`/`allow_can_write` is disabled, `python-can` is not installed (`can_backend_not_available` -> install `agentic_hil[can]`), another program owns the adapter, or the `channel` value is for a different backend.
+Likely cause: the bus is not configured under `can_buses`, the wrong `bus_id` is used, `allow_can_read`/`allow_can_write` is disabled, `python-can` is not installed (`can_backend_not_available` -> install `agentic-hil[can]`), another program owns the adapter, or the `channel` value is for a different backend.
 
 Fix: add only the approved project bus to `.agentic-hil/config.yaml` and use MCP CAN tools with the configured `bus_id`. On Windows with PEAK, use `adapter: "peak"` and `channel: "PCAN_USBBUS1"`. On Linux SocketCAN, use `adapter: "socketcan"` and an interface such as `can0` — `PCAN_USBBUS*` values are Windows PCANBasic channels, not SocketCAN interface names.
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -1,6 +1,6 @@
 # Release Strategy
 
-Agentic HIL publishes through PyPI and GitHub Releases. GitHub Releases trigger publishing and carry release notes; PyPI is the canonical installation channel (`pip install agentic_hil`, `uv tool install agentic_hil`, `pipx install agentic_hil`).
+Agentic Hardware-in-the-Loop (Agentic HIL) publishes through PyPI and GitHub Releases. GitHub Releases trigger publishing and carry release notes; PyPI is the canonical installation channel (`pip install agentic-hil`, `uv tool install agentic-hil`, `pipx install agentic-hil`).
 
 Do not cut the next release for metadata-only or README-only cleanup. Batch hygiene work into the next release that delivers visible user value.
 
@@ -34,7 +34,7 @@ links to relevant docs
 
 PyPI first. Publishing runs through GitHub Actions trusted publishing with OIDC (`.github/workflows/workflow.yml`) — no long-lived PyPI API tokens. The workflow builds sdist and wheel, validates them with twine, and refuses releases whose tag does not match the `pyproject.toml` version.
 
-Naming is part of the release contract: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Naming is part of the release contract: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 Later packaging candidates are Homebrew, Scoop or WinGet, and conda-forge — add them only when they are reproducible and built by CI.
 
@@ -49,7 +49,7 @@ Before creating a release:
 4. Merge to master and let the CI matrix pass.
 5. Create a GitHub Release with a strict SemVer vX.Y.Z tag that exactly matches pyproject.toml.
 6. Let the publish workflow validate the tag, build, check, and publish to PyPI.
-7. Verify: uvx --from agentic_hil agentic-hil --version resolves the new version from PyPI.
+7. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
 8. Start from GitHub auto-generated release notes, then edit for clarity.
 ```
 

--- a/docs/security-design.md
+++ b/docs/security-design.md
@@ -1,6 +1,6 @@
 # Security Design
 
-Agentic HIL is a local MCP stdio server for agent-driven embedded hardware workflows. Its security design focuses on keeping host and hardware actions explicit, narrow, configured, and auditable.
+Agentic Hardware-in-the-Loop (Agentic HIL) is a local MCP stdio server for agent-driven embedded hardware workflows. Its security design focuses on keeping host and hardware actions explicit, narrow, configured, and auditable.
 
 ## Threat Model
 

--- a/examples/adapters/README.md
+++ b/examples/adapters/README.md
@@ -1,6 +1,6 @@
 # Agentic HIL Test Adapter Bridges
 
-A test adapter simulates what standard lab equipment cannot: realistic sensors, actuator loads, and fault states (open sensor, short to GND/VCC, contact bounce, blocked motor). Agentic HIL talks to adapters through a small bridge protocol so that hardware adapters and pure-software simulators are interchangeable.
+Agentic Hardware-in-the-Loop (Agentic HIL) talks to test adapters through a small bridge protocol so that hardware adapters and pure-software simulators are interchangeable. A test adapter simulates what standard lab equipment cannot: realistic sensors, actuator loads, and fault states (open sensor, short to GND/VCC, contact bounce, blocked motor).
 
 ## Configure an adapter
 

--- a/examples/nucleo-f446re_demo/README.md
+++ b/examples/nucleo-f446re_demo/README.md
@@ -1,6 +1,6 @@
 # Nucleo-F446RE Demo: Real Firmware in the Agentic HIL Loop
 
-A minimal bare-metal STM32F446RE firmware for the [ST Nucleo-F446RE](https://www.st.com/en/evaluation-tools/nucleo-f446re.html) board that demonstrates the complete Agentic HIL loop on real hardware: build → flash → reset → assert on serial output.
+A minimal bare-metal STM32F446RE firmware for the [ST Nucleo-F446RE](https://www.st.com/en/evaluation-tools/nucleo-f446re.html) board that demonstrates the complete Agentic Hardware-in-the-Loop (Agentic HIL) loop on real hardware: build → flash → reset → assert on serial output.
 
 The firmware prints `Hello World` on USART2 (PA2/PA3, routed to the ST-LINK virtual COM port, 115200 baud) at boot and then blinks the LD2 user LED. No HAL, no external dependencies — the whole program is [Src/main.c](Src/main.c).
 
@@ -21,10 +21,10 @@ This produces `build/Debug/nucleo-f446re_demo.elf` (plus `.hex`/`.bin`) — insi
 
 ## Configure Agentic HIL
 
-Names: the Python package/install target uses `agentic_hil`; the CLI command uses `agentic-hil`. Python-facing identifiers such as pytest fixtures and Python examples use `agentic_hil`.
+Names: the Python distribution/install target and CLI command use `agentic-hil`. Python-facing identifiers such as pytest fixtures and Python examples use `agentic_hil`.
 
 ```bash
-pipx install agentic_hil
+pipx install agentic-hil
 mkdir -p .agentic-hil && cp agentic-hil.config.example.yaml .agentic-hil/config.yaml
 # adjust com_ports.dut_uart.device (e.g. /dev/ttyACM0, COM5), then:
 agentic-hil doctor

--- a/examples/nucleo-f446re_demo/tests/test_firmware.py
+++ b/examples/nucleo-f446re_demo/tests/test_firmware.py
@@ -6,7 +6,7 @@ Build the firmware first, then run pytest from this demo directory with a
     cmake --preset Debug && cmake --build --preset Debug
     pytest tests/
 
-Without a Agentic HIL configuration the test is skipped; with a configuration but
+Without an Agentic HIL configuration the test is skipped; with a configuration but
 no board attached it fails — that is the point of a hardware-in-the-loop test.
 """
 from __future__ import annotations

--- a/examples/pytest/test_ntc_diagnosis.py
+++ b/examples/pytest/test_ntc_diagnosis.py
@@ -1,11 +1,11 @@
-"""Example: temperature-sensor diagnosis loop driven by the Agentic HIL pytest plugin.
+"""Example: temperature-sensor diagnosis loop driven by the Agentic Hardware-in-the-Loop (Agentic HIL) pytest plugin.
 
 Run from a checkout of the agentic-hil repository (or copy this file together with
 examples/adapters/sim_ntc_adapter.py into your firmware project) with a
 .agentic-hil/config.yaml whose adapters section points at the simulator, as shown
 in examples/adapters/README.md:
 
-    pip install agentic_hil
+    pip install agentic-hil
     pytest test_ntc_diagnosis.py
 
 The `agentic_hil` fixture skips these tests when no Agentic HIL configuration file

--- a/llms.txt
+++ b/llms.txt
@@ -1,26 +1,26 @@
 # Agentic HIL
 
-Agentic HIL is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection. Agentic HIL adapters are the reference hardware.
+Agentic Hardware-in-the-Loop (Agentic HIL) is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection. HardCI adapters are the reference hardware.
 
 Canonical setup request: `Install from https://github.com/hp-8472/agentic-hil and set it up for this project.`
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 First normal pip attempt:
 
 ```bash
-python -m pip install --user agentic_hil
+python -m pip install --user agentic-hil
 agentic-hil --version
 ```
 
 Run without installing (no admin rights, no PATH changes):
 
 ```bash
-uvx --from agentic_hil agentic-hil --version
+uvx --from agentic-hil agentic-hil --version
 uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
 ```
 
-Alternative isolated user-local install: `uv tool install agentic_hil` or `pipx install agentic_hil`. Never sudo, never --break-system-packages. Requires Python 3.10+.
+Alternative isolated user-local install: `uv tool install agentic-hil` or `pipx install agentic-hil`. Never sudo, never --break-system-packages. Requires Python 3.10+.
 
 Bootstrap each firmware project from the project directory:
 
@@ -58,7 +58,7 @@ Required workflow:
 4. Stimulate via com/can/adapter tools, assert on feedback.
 5. Read the structured result and last report; classify failures before changing code again.
 
-pytest: installing `agentic_hil` registers the Python plugin `agentic_hil`; the `agentic_hil` fixture drives the same tools in CI regression suites.
+pytest: installing `agentic-hil` registers the Python plugin `agentic_hil`; the `agentic_hil` fixture drives the same tools in CI regression suites.
 
 Safety: do not request raw OpenOCD commands, do not open host serial/CAN/adapter devices directly, do not flash outside allowed artifact roots. Treat `permission_denied` as authoritative.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.3.0"
+version = "0.2.2"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agentic_hil"
-version = "0.2.1"
-description = "Agentic hardware-in-the-loop tools for AI-assisted embedded firmware loops"
+name = "agentic-hil"
+version = "0.3.0"
+description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.3.0"
+__version__ = "0.2.2"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/backends/pyocd.py
+++ b/src/agentic_hil/backends/pyocd.py
@@ -24,7 +24,7 @@ PYOCD_NOT_FOUND: JsonObject = {
     "summary": "pyOCD executable could not be found.",
     "likely_causes": [
         "debugger.executable is not configured",
-        "pyOCD is not installed (install agentic_hil[pyocd] or pip install pyocd)",
+        "pyOCD is not installed (install agentic-hil[pyocd] or pip install pyocd)",
         "pyocd is not in PATH",
     ],
 }
@@ -286,5 +286,5 @@ class PyOCDBackend:
             "flash_failed": ["target flash is locked", "firmware image is invalid for this target", "debugger.flash_address is wrong"],
             "reset_failed": ["reset line wiring issue", "target is not responding"],
             "timeout": ["debugger stopped responding", "debug probe or target is stuck", "timeout_s is too low for this operation"],
-            "debugger_not_found": ["debugger.executable is not configured", "pyOCD is not installed (install agentic_hil[pyocd] or pip install pyocd)", "pyocd is not in PATH"],
+            "debugger_not_found": ["debugger.executable is not configured", "pyOCD is not installed (install agentic-hil[pyocd] or pip install pyocd)", "pyocd is not in PATH"],
         }.get(error_type, ["inspect the debugger log for details"])

--- a/src/agentic_hil/can.py
+++ b/src/agentic_hil/can.py
@@ -265,7 +265,7 @@ def open_python_can_adapter(config: AgenticHILConfig, bus_id: str, bus_config: C
     try:
         import can
     except ImportError:
-        return {"ok": False, "tool": "can_session_start", "bus_id": bus_id, "adapter": bus_config.adapter, "error_type": "can_backend_not_available", "summary": "python-can is not installed. Install agentic_hil[can] to use direct CAN adapters."}
+        return {"ok": False, "tool": "can_session_start", "bus_id": bus_id, "adapter": bus_config.adapter, "error_type": "can_backend_not_available", "summary": "python-can is not installed. Install agentic-hil[can] to use direct CAN adapters."}
     try:
         interface = "pcan" if bus_config.adapter == "peak" else "socketcan"
         bus = can.Bus(interface=interface, channel=bus_config.channel, bitrate=bus_config.bitrate, fd=bus_config.fd, receive_own_messages=bus_config.receive_own_messages)

--- a/src/agentic_hil/cli.py
+++ b/src/agentic_hil/cli.py
@@ -121,7 +121,7 @@ def entrypoint(argv: list[str] | None = None) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="agentic-hil", description="Agentic HIL local MCP stdio server")
+    parser = argparse.ArgumentParser(prog="agentic-hil", description="Agentic Hardware-in-the-Loop (Agentic HIL) local MCP stdio server")
     parser.add_argument("--version", action="version", version=__version__)
     subparsers = parser.add_subparsers(dest="command")
 

--- a/src/agentic_hil/mcp.py
+++ b/src/agentic_hil/mcp.py
@@ -94,7 +94,7 @@ MCP_TOOLS: list[JsonObject] = [
     {"name": "adapter_measure", "description": "Measure a configured test adapter channel and return the structured value.", "inputSchema": {"type": "object", "properties": {"adapter_id": {"type": "string"}, "channel": {"type": "string"}}, "required": ["adapter_id", "channel"], "additionalProperties": False}},
 ]
 
-AGENTIC_HIL_WORKFLOW_PROMPT = """Use Agentic HIL as the safe gate to the configured embedded hardware.
+AGENTIC_HIL_WORKFLOW_PROMPT = """Use Agentic Hardware-in-the-Loop (Agentic HIL) as the safe gate to the configured embedded hardware.
 
 Workflow:
 1. Build the firmware first.

--- a/src/agentic_hil/pytest_plugin.py
+++ b/src/agentic_hil/pytest_plugin.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--agentic-hil-config",
         action="store",
         default=None,
-        help=f"Path to the Agentic HIL project configuration (default: {DEFAULT_CONFIG_PATH}).",
+        help=f"Path to the Agentic Hardware-in-the-Loop (Agentic HIL) project configuration (default: {DEFAULT_CONFIG_PATH}).",
     )
     parser.addini("agentic_hil_config", help="Path to the Agentic HIL project configuration.", default=None)
 

--- a/src/agentic_hil/schemas/config.schema.json
+++ b/src/agentic_hil/schemas/config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentic-hil.local/schemas/config.schema.json",
-  "title": "Agentic HIL project configuration",
+  "title": "Agentic Hardware-in-the-Loop (Agentic HIL) project configuration",
   "description": "Schema for project-local .agentic-hil/config.yaml files.",
   "type": "object",
   "additionalProperties": false,

--- a/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil-config-setup
 description: Configure Agentic Hardware-in-the-Loop (Agentic HIL) as the safe local MCP bridge for an embedded firmware project.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.3.0"
+  agentic_hil_version: "0.2.2"
 ---
 
 # Agentic HIL Config Setup

--- a/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: agentic-hil-config-setup
-description: Configure Agentic HIL as the safe local hardware-in-the-loop MCP bridge for an embedded firmware project.
+description: Configure Agentic Hardware-in-the-Loop (Agentic HIL) as the safe local MCP bridge for an embedded firmware project.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.2.1"
+  agentic_hil_version: "0.3.0"
 ---
 
 # Agentic HIL Config Setup
 
 Use Agentic HIL as the project-local hardware gate. The policy file is `.agentic-hil/config.yaml`.
 
-Names: the Python package/install target and Python-facing identifiers such as imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`. The CLI command, repository URL, and MCP server name use `agentic-hil`.
+Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 Install and initialize from the firmware project directory:
 

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from conftest import FAKE_STLINK_UNCONFIRMED, SIM_NTC_ADAPTER, write_config
 
+from agentic_hil import __version__
 from agentic_hil.artifacts import ArtifactManager
 from agentic_hil.can import CanFrame, ProcessCanAdapterSession, open_python_can_adapter
 from agentic_hil.cli import init_config, install_skill, mcp_config, schema
@@ -17,6 +18,16 @@ from agentic_hil.comports import ComPortService
 from agentic_hil.config import ConfigError, load_config
 from agentic_hil.mcp import MCP_PROTOCOL_VERSION, MCP_TOOL_NAMES, MCP_TOOLS, handle_mcp_message
 from agentic_hil.tools import AgenticHILToolService
+
+
+def test_release_metadata_uses_canonical_name_and_version() -> None:
+    repository_root = Path(__file__).resolve().parents[1]
+    metadata = (repository_root / "pyproject.toml").read_text(encoding="utf-8")
+    skill = (repository_root / "src" / "agentic_hil" / "skills" / "agentic-hil-config-setup" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert '\nname = "agentic-hil"\n' in metadata
+    assert f'\nversion = "{__version__}"\n' in metadata
+    assert f'agentic_hil_version: "{__version__}"' in skill
 
 
 def mcp_tool_call(service: AgenticHILToolService, name: str, arguments: dict | None = None) -> dict:
@@ -39,7 +50,7 @@ def test_schema_exports_bundled_config_schema(tmp_path: Path) -> None:
     schema_path = tmp_path / "config.schema.json"
     result = schema(str(schema_path))
     assert result["ok"] is True
-    assert "Agentic HIL project configuration" in schema_path.read_text(encoding="utf-8")
+    assert "Agentic Hardware-in-the-Loop (Agentic HIL) project configuration" in schema_path.read_text(encoding="utf-8")
 
 
 def test_mcp_config_writes_project_mcp_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- publish the complete Agentic HIL naming migration as v0.2.2
- canonicalize the distribution/install name as agentic-hil while keeping Python imports and the pytest fixture as agentic_hil
- identify HardCI adapters as the reference hardware and expand the first public software mention
- remove all current hardci compatibility surfaces while preserving accurate historical changelog entries
- add a regression test for canonical package metadata and synchronized release versions

## Validation
- ruff check src tests examples
- pytest: 71 passed, 1 skipped on Python 3.13
- python -m build
- twine check dist/*
- clean wheel install: CLI/import version 0.2.2 and no hardci package
- independent release-blocker review: no remaining findings

## Release
After merge and green Required CI, publish GitHub Release v0.2.2 to trigger trusted PyPI publishing and release attestations.