### PR TITLE
docs: update repository URLs after transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Troubleshooting guide
-    url: https://github.com/hp-8472/agentic-hil/blob/master/TROUBLESHOOTING.md
+    url: https://github.com/agentic-hil/agentic-hil/blob/master/TROUBLESHOOTING.md
     about: Start here for debugger, target detection, artifact validation, and COM-port setup failures.
   - name: Security policy
-    url: https://github.com/hp-8472/agentic-hil/security/policy
+    url: https://github.com/agentic-hil/agentic-hil/security/policy
     about: Report security issues and hardware-safety concerns through the documented security process.

--- a/AI_AGENT_QUICKSTART.md
+++ b/AI_AGENT_QUICKSTART.md
@@ -7,7 +7,7 @@ This file is for agents. Humans should start with `README.md` and use `TROUBLESH
 Canonical copy/paste user request:
 
 ```text
-Install from https://github.com/hp-8472/agentic-hil and set it up for this project.
+Install from https://github.com/agentic-hil/agentic-hil and set it up for this project.
 ```
 
 If you were given only the Agentic HIL repository URL and asked to set it up: run the fast path below, install the Agentic HIL skill into your own skill directory, configure the firmware project, then return to the firmware project. Do not clone, checkout, or vendor the Agentic HIL source tree into the firmware project for normal setup.
@@ -51,10 +51,10 @@ uvx --from agentic-hil agentic-hil --version
 4. If the PyPI package lookup fails, use the repository as the package source (this is a package source only — it does not create a checkout):
 
 ```bash
-uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
+uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version
 ```
 
-5. If `uv` is missing but `pipx` is available, the equivalents are `pipx run --spec agentic-hil agentic-hil --version` and `pipx run --spec git+https://github.com/hp-8472/agentic-hil agentic-hil --version`.
+5. If `uv` is missing but `pipx` is available, the equivalents are `pipx run --spec agentic-hil agentic-hil --version` and `pipx run --spec git+https://github.com/agentic-hil/agentic-hil agentic-hil --version`.
 6. If neither `uv` nor `pipx` is available, install `uv` user-locally (no admin rights; installs to `~/.local/bin`):
 
 ```bash
@@ -66,7 +66,7 @@ then rerun step 3. A missing runner is a remediable setup prerequisite, not a re
 If the `pip --user` command is not reliably on `PATH`, use an isolated persistent install for the MCP server entry (still user-local, still no admin rights):
 
 ```bash
-uv tool install agentic-hil        # or from the repository: uv tool install git+https://github.com/hp-8472/agentic-hil
+uv tool install agentic-hil        # or from the repository: uv tool install git+https://github.com/agentic-hil/agentic-hil
 ```
 
 `pipx install agentic-hil` is the equivalent. Both place `agentic-hil` into `~/.local/bin`; if that is not on `PATH`, fix it with `uv tool update-shell` or `pipx ensurepath` — never with admin rights.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- Updated canonical repository URLs after the transfer to `agentic-hil/agentic-hil`.
+
 ## [0.2.2] - 2026-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Names: the Python distribution/install target, CLI command, repository URL, MCP 
 The easiest path: copy/paste this prompt to your AI agent:
 
 ```text
-Install from https://github.com/hp-8472/agentic-hil and set it up for this project.
+Install from https://github.com/agentic-hil/agentic-hil and set it up for this project.
 ```
 
 Agents follow [AI_AGENT_QUICKSTART.md](AI_AGENT_QUICKSTART.md) — everything installs user-local, **no admin rights required, ever**.
@@ -39,7 +39,7 @@ Without installing anything (no `PATH` changes; needs [uv](https://docs.astral.s
 
 ```bash
 uvx --from agentic-hil agentic-hil --version
-uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
+uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version
 ```
 
 Alternative isolated user-local install (recommended when the MCP client needs a stable command on `PATH`):

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,7 +31,7 @@ If that fails, use `uv` or `pipx` instead:
 
 ```bash
 uvx --from agentic-hil agentic-hil --version                                  # run without installing
-uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version    # repository as package source
+uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version    # repository as package source
 uv tool install agentic-hil                                                    # isolated user-local install
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 Agentic Hardware-in-the-Loop (Agentic HIL) is a local MCP stdio server that gives AI agents safe, policy-gated access to real embedded hardware: flashing, serial, CAN, and test-adapter stimuli/fault injection. HardCI adapters are the reference hardware.
 
-Canonical setup request: `Install from https://github.com/hp-8472/agentic-hil and set it up for this project.`
+Canonical setup request: `Install from https://github.com/agentic-hil/agentic-hil and set it up for this project.`
 
 Names: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
@@ -17,7 +17,7 @@ Run without installing (no admin rights, no PATH changes):
 
 ```bash
 uvx --from agentic-hil agentic-hil --version
-uvx --from git+https://github.com/hp-8472/agentic-hil agentic-hil --version
+uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version
 ```
 
 Alternative isolated user-local install: `uv tool install agentic-hil` or `pipx install agentic-hil`. Never sudo, never --break-system-packages. Requires Python 3.10+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/hp-8472/agentic-hil"
-Repository = "https://github.com/hp-8472/agentic-hil.git"
-Issues = "https://github.com/hp-8472/agentic-hil/issues"
+Homepage = "https://github.com/agentic-hil/agentic-hil"
+Repository = "https://github.com/agentic-hil/agentic-hil.git"
+Issues = "https://github.com/agentic-hil/agentic-hil/issues"
 
 [project.scripts]
 agentic-hil = "agentic_hil.cli:entrypoint"


### PR DESCRIPTION
## Summary

- update package metadata and public setup docs to the new `agentic-hil/agentic-hil` repository URL
- update issue-template links after the organization transfer
- record the transfer in the changelog

## Verification

- `71 passed, 1 skipped` on Python 3.13
- `python -m build`
- `twine check dist/*`
- `uvx --from agentic-hil==0.2.2 agentic-hil --version`
- `uvx --from git+https://github.com/agentic-hil/agentic-hil agentic-hil --version`

Tracks the remaining metadata work in hp-8472/hardci-hq#60.