### PR TITLE
feat: publish Agentic HIL to MCP Registry

### DIFF
--- a/.github/scripts/install-mcp-publisher.sh
+++ b/.github/scripts/install-mcp-publisher.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly VERSION="v1.8.0"
+readonly SHA256="1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
+readonly URL="https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
+readonly DESTINATION="${1:?usage: install-mcp-publisher.sh OUTPUT_PATH}"
+
+archive="$(mktemp)"
+extract_dir="$(mktemp -d)"
+trap 'rm -f "$archive"; rm -rf "$extract_dir"' EXIT
+
+curl --fail --location --retry 3 --output "$archive" "$URL"
+echo "${SHA256}  ${archive}" | sha256sum -c
+mkdir -p "$(dirname "$DESTINATION")"
+tar --extract --gzip --file "$archive" --directory "$extract_dir" mcp-publisher
+rm -f "$DESTINATION"
+mv "$extract_dir/mcp-publisher" "$DESTINATION"
+chmod +x "$DESTINATION"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -50,6 +51,109 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: publish
+    if: ${{ always() && ((github.event_name == 'release' && needs.publish.result == 'success') || (github.event_name == 'workflow_dispatch' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch)) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Verify release metadata versions
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          package_version = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+          registry = json.loads(pathlib.Path("server.json").read_text(encoding="utf-8"))
+          versions = {
+              package_version,
+              registry["version"],
+              registry["packages"][0]["version"],
+          }
+          release_tag = os.environ.get("RELEASE_TAG")
+          if release_tag:
+              versions.add(release_tag.removeprefix("v"))
+          if len(versions) != 1:
+              raise SystemExit(f"release, package, and registry versions differ: {sorted(versions)}")
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as environment:
+              environment.write(f"MCP_RELEASE_VERSION={package_version}\n")
+          PY
+
+      - name: Wait for verifiable PyPI metadata
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["MCP_RELEASE_VERSION"]
+          url = f"https://pypi.org/pypi/agentic-hil/{version}/json"
+          marker = "<!-- mcp-name: io.github.agentic-hil/agentic-hil -->"
+          for attempt in range(12):
+              try:
+                  with urllib.request.urlopen(url, timeout=15) as response:
+                      metadata = json.load(response)
+                  if marker in metadata["info"]["description"]:
+                      break
+              except (OSError, urllib.error.HTTPError, json.JSONDecodeError):
+                  pass
+              if attempt == 11:
+                  raise SystemExit(f"PyPI metadata for agentic-hil {version} is not registry-verifiable")
+              time.sleep(10)
+          PY
+
+      - name: Install pinned MCP publisher
+        run: |
+          echo "MCP_PUBLISHER=$RUNNER_TEMP/mcp-publisher" >> "$GITHUB_ENV"
+          bash .github/scripts/install-mcp-publisher.sh "$RUNNER_TEMP/mcp-publisher"
+
+      - name: Validate server metadata
+        run: |
+          "$MCP_PUBLISHER" validate server.json
+
+      - name: Authenticate to MCP Registry
+        run: |
+          "$MCP_PUBLISHER" login github-oidc
+
+      - name: Publish to MCP Registry
+        run: |
+          for attempt in 1 2 3 4; do
+            if "$MCP_PUBLISHER" publish server.json; then
+              exit 0
+            fi
+            status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/$MCP_RELEASE_VERSION" || true)"
+            if [[ "$status" == "200" ]]; then
+              echo "MCP Registry already contains io.github.agentic-hil/agentic-hil $MCP_RELEASE_VERSION"
+              exit 0
+            fi
+            if [[ "$attempt" == "4" ]]; then
+              echo "MCP Registry publication failed after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 10))"
+          done
 
   release-assets:
     name: Attach SBOM and attestations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-14
+
 ### Changed
 
 - Updated canonical repository URLs after the transfer to `agentic-hil/agentic-hil`.
+- Added official MCP Registry metadata, validation, and OIDC publishing after each successful PyPI release while retaining the host-independent local setup path.
 
 ## [0.2.2] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentic HIL
 
+<!-- mcp-name: io.github.agentic-hil/agentic-hil -->
+
 **Your AI agent can develop firmware on its own — because Agentic Hardware-in-the-Loop (Agentic HIL) closes the loop with real hardware.**
 
 ```
@@ -81,6 +83,17 @@ Project-local `.mcp.json`:
   }
 }
 ```
+
+Agentic HIL releases are published to the preview official MCP Registry as `io.github.agentic-hil/agentic-hil`, pointing to the same public PyPI package and `mcp-stdio` command. The registry is a discovery channel, not a substitute for project setup or policy review. The host-independent manual path remains supported:
+
+```bash
+uv tool install agentic-hil
+agentic-hil init
+agentic-hil doctor
+agentic-hil mcp-config --output .mcp.json
+```
+
+Registry installation never grants additional hardware access. Every action is still constrained by the project-local `.agentic-hil/config.yaml`; review [SECURITY.md](SECURITY.md) before enabling unattended hardware access.
 
 ## Configuration
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -34,6 +34,10 @@ links to relevant docs
 
 PyPI first. Publishing runs through GitHub Actions trusted publishing with OIDC (`.github/workflows/workflow.yml`) — no long-lived PyPI API tokens. The workflow builds sdist and wheel, validates them with twine, and refuses releases whose tag does not match the `pyproject.toml` version.
 
+After PyPI accepts a release, the same workflow verifies the package's `mcp-name` ownership marker and publishes `server.json` to the preview MCP Registry through GitHub Actions OIDC. No MCP Registry secret is stored. The release tag, Python package version, top-level server version, and package version in `server.json` must match exactly. The registry is an additional discovery channel; the documented local CLI and MCP configuration path remains authoritative and host-independent.
+
+If MCP Registry publication fails after PyPI succeeds, re-run only the failed job or manually dispatch the release workflow from the protected default branch. Manual dispatch from any other ref is skipped; the valid recovery path skips PyPI and republishes only the already released, synchronized registry metadata.
+
 Naming is part of the release contract: the Python distribution/install target, CLI command, repository URL, and MCP server name use `agentic-hil`. Python imports, pytest plugin names, fixtures, and Python examples use `agentic_hil`.
 
 Later packaging candidates are Homebrew, Scoop or WinGet, and conda-forge — add them only when they are reproducible and built by CI.
@@ -43,14 +47,16 @@ Later packaging candidates are Homebrew, Scoop or WinGet, and conda-forge — ad
 Before creating a release:
 
 ```text
-1. Update pyproject.toml version and CHANGELOG.md together.
+1. Update pyproject.toml, `src/agentic_hil/__init__.py`, the bundled skill, `server.json`, and CHANGELOG.md together.
 2. Run ruff check src tests examples and pytest.
 3. Run python -m build (or uv build) and inspect the packaged files.
 4. Merge to master and let the CI matrix pass.
 5. Create a GitHub Release with a strict SemVer vX.Y.Z tag that exactly matches pyproject.toml.
 6. Let the publish workflow validate the tag, build, check, and publish to PyPI.
-7. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
-8. Start from GitHub auto-generated release notes, then edit for clarity.
+7. Let the workflow verify the PyPI ownership marker and publish the matching `server.json` through GitHub OIDC.
+8. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
+9. Verify the release appears as `io.github.agentic-hil/agentic-hil` in the MCP Registry API.
+10. Start from GitHub auto-generated release notes, then edit for clarity.
 ```
 
 ## Repository Protection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.2.2"
+version = "0.2.3"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.agentic-hil/agentic-hil",
+  "title": "Agentic HIL",
+  "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+  "version": "0.2.3",
+  "repository": {
+    "url": "https://github.com/agentic-hil/agentic-hil",
+    "source": "github",
+    "id": "1278450589"
+  },
+  "websiteUrl": "https://github.com/agentic-hil/agentic-hil",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "agentic-hil",
+      "version": "0.2.3",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp-stdio"
+        }
+      ]
+    }
+  ]
+}

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil-config-setup/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil-config-setup
 description: Configure Agentic Hardware-in-the-Loop (Agentic HIL) as the safe local MCP bridge for an embedded firmware project.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.2.2"
+  agentic_hil_version: "0.2.3"
 ---
 
 # Agentic HIL Config Setup

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -24,10 +24,31 @@ def test_release_metadata_uses_canonical_name_and_version() -> None:
     repository_root = Path(__file__).resolve().parents[1]
     metadata = (repository_root / "pyproject.toml").read_text(encoding="utf-8")
     skill = (repository_root / "src" / "agentic_hil" / "skills" / "agentic-hil-config-setup" / "SKILL.md").read_text(encoding="utf-8")
+    readme = (repository_root / "README.md").read_text(encoding="utf-8")
+    registry = json.loads((repository_root / "server.json").read_text(encoding="utf-8"))
 
     assert '\nname = "agentic-hil"\n' in metadata
     assert f'\nversion = "{__version__}"\n' in metadata
     assert f'agentic_hil_version: "{__version__}"' in skill
+    assert "<!-- mcp-name: io.github.agentic-hil/agentic-hil -->" in readme
+    assert registry["name"] == "io.github.agentic-hil/agentic-hil"
+    assert registry["version"] == __version__
+    assert registry["repository"] == {
+        "url": "https://github.com/agentic-hil/agentic-hil",
+        "source": "github",
+        "id": "1278450589",
+    }
+    assert registry["packages"] == [
+        {
+            "registryType": "pypi",
+            "registryBaseUrl": "https://pypi.org",
+            "identifier": "agentic-hil",
+            "version": __version__,
+            "runtimeHint": "uvx",
+            "transport": {"type": "stdio"},
+            "packageArguments": [{"type": "positional", "value": "mcp-stdio"}],
+        }
+    ]
 
 
 def mcp_tool_call(service: AgenticHILToolService, name: str, arguments: dict | None = None) -> dict:


### PR DESCRIPTION
## Summary

- add official `server.json` metadata for `io.github.agentic-hil/agentic-hil` and the PyPI ownership marker
- publish Registry metadata after a successful PyPI release through GitHub OIDC with a pinned, checksum-verified publisher
- keep Registry outages out of required PR checks and provide a default-branch-only recovery dispatch
- synchronize the first Registry-enabled release as `0.2.3` while preserving the manual host-independent MCP setup path

## Verification

- official `mcp-publisher` v1.8.0: `server.json is valid`
- `ruff check src tests examples`
- `pytest`: 71 passed, 1 skipped on Python 3.13
- package build and `twine check`: passed
- built wheel contains the exact PyPI `mcp-name` ownership marker
- local `uvx --from . agentic-hil --version`: 0.2.3
- local `agentic-hil mcp-config` smoke test: passed
- focused release/security review: no remaining P0-P2 findings

## Release

After merge and green Required CI, publish GitHub Release `v0.2.3`. The release workflow will publish PyPI first, verify the package marker, then publish and verify the MCP Registry entry.

Tracks hp-8472/hardci-hq#26.