### PR TITLE
chore: release Agentic HIL v0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Safe embedded firmware development with hardware-in-the-loop targets via policy-gated MCP tools.",
       "source": "./plugins/agentic-hil",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
-## [Unreleased]
+## [0.5.0] - 2026-08-02
 
 ### Changed
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix — all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.4.0"
+python -m pip install --user --upgrade "agentic-hil>=0.5.0"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -31,12 +31,12 @@ agentic-hil setup --help
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.4.0" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.4.0 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.4.0"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.5.0" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.5.0 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.5.0"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.4.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.4.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.5.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.5.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Do not store `uvx`, a workspace virtual environment, or a bare PATH command in `.mcp.json` or a user-level MCP registration. Run `agentic-hil setup --agent <agent>` for Claude Code, Codex, or OpenCode; it verifies the persistent executable and stores its absolute user-bin path. For another host, review that same persistent executable and configure its absolute path as described in [MCP host configuration](docs/mcp-hosts.md).
 

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Safe embedded firmware development with local hardware-in-the-loop targets, exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN).",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.4.0"
+  agentic_hil_version: "0.5.0"
 ---
 
 # Agentic HIL
@@ -86,11 +86,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.4.0"
+uv tool install --upgrade "agentic-hil==0.5.0"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.4.0`. If `uv` is unavailable or a
+The version check must report exactly `0.5.0`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. Then, from the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.4.0"
+version = "0.5.0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.4.0"
+  agentic_hil_version: "0.5.0"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
Prepares the v0.5.0 release. No behaviour changes — the shipped code is what #55 merged.

Breaking changes to the authoritative configuration make this a minor bump under pre-1.0 SemVer rather than a patch: permissions moved onto the device they authorize, the `devices:` and singleton `debugger:` blocks are gone, the test plan format is version 2, and test adapters are removed until the first real adapter exists. Going to 1.0.0 would signal API stability, which is a product call rather than a mechanical consequence of the diff.

Moves every version source the publish workflow compares:

| Source | |
|---|---|
| `pyproject.toml`, `src/agentic_hil/__init__.py` | package version |
| `server.json` | top-level and package version |
| `.claude-plugin/marketplace.json`, plugin manifest | 0.5.0 |
| packaged skill, plugin skill | `agentic_hil_version` |
| `CHANGELOG.md` | `[Unreleased]` becomes `[0.5.0] - 2026-08-02` |

Also updates the package pin in the plugin skill (`agentic-hil==0.5.0`) and the install pins in `TROUBLESHOOTING.md`, which `tools/check_shipped_references.py` caught still reading 0.4.0.

## Verification

- The publish workflow's release-metadata contract reproduced locally: all nine sources plus a simulated `v0.5.0` tag agree
- `pytest`: 604 passed, 27 skipped
- `ruff check src tests evals tools`
- `python tools/check_shipped_references.py`
- `python -m build` produces `agentic_hil-0.5.0` sdist and wheel; `twine check` passes both

## Not included

Six open Scorecard `Pinned-Dependencies` alerts (#60–#65) are pre-existing on master and untouched here, to keep the publish path out of the release diff.