### PR TITLE
fix: keep the CAN drain budget off the pre-drain audit write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Fixed
+
+- The CAN receive-queue drain budget bounds time spent talking to the adapter instead of also covering the `queue_clear_start` audit write that precedes it. The one-second deadline was armed before that write, so a slow first append — a cold runner creating the JSONL log while a scanner holds it — could consume the whole budget and break the loop before a single frame was read, failing `can_session_start` with `can_queue_clear_limit` and `frames_drained: 0` on a queue that was never touched.
+
 ## [0.5.0] - 2026-08-02
 
 ### Changed

--- a/src/agentic_hil/can.py
+++ b/src/agentic_hil/can.py
@@ -358,12 +358,13 @@ class CanBusService:
 
     def _drain_rx_queue(self, session: CanBusSession) -> JsonObject:
         drained = 0
-        deadline = time.monotonic() + CAN_DRAIN_TIMEOUT_S
         audit_error = append_jsonl_audited(self.config, session.log_path, {"event": "queue_clear_start", "bus_id": session.bus_id})
         if audit_error is not None:
             session.audit_broken = True
             session.lease.quarantine("can_queue_clear_audit_broken", audit_error, audit_broken=True)
             return mark_audit_failure({"ok": False, "tool": "can_session_start", "bus_id": session.bus_id, "error_type": "can_queue_clear_failed", "summary": "CAN receive queue clear could not be audited before execution.", "side_effect_committed": False, "side_effect_status": "not_started"}, audit_error)
+        # The drain budget bounds adapter time only, so it starts after the pre-drain audit write.
+        deadline = time.monotonic() + CAN_DRAIN_TIMEOUT_S
         for _ in range(CAN_DRAIN_BATCH_LIMIT):
             if time.monotonic() >= deadline:
                 break

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -20,7 +20,7 @@ from agentic_hil.artifacts import ArtifactManager
 from agentic_hil.backends.common import spawn_command
 from agentic_hil.backends.gdbdebug import GdbDebugSessions
 from agentic_hil.bridge import BridgeCleanupError, ProcessBridgeSession
-from agentic_hil.can import CanBusService, CanBusSession, parse_can_id, payload_frame
+from agentic_hil.can import CAN_DRAIN_TIMEOUT_S, CanBusService, CanBusSession, parse_can_id, payload_frame
 from agentic_hil.cli import debugger_probes
 from agentic_hil.comports import ComPortService, ComPortSession
 from agentic_hil.comstdio import run_com_stdio
@@ -41,6 +41,7 @@ from agentic_hil.mcp import handle_mcp_message
 from agentic_hil.report import (
     append_canonical_audit_log,
     append_jsonl,
+    append_jsonl_audited,
     attach_canonical_audit_evidence,
     canonical_audit_evidence,
     canonical_audit_log_path,
@@ -615,6 +616,80 @@ def test_active_can_session_quarantines_when_queue_never_drains(tmp_path: Path) 
     assert result["frames_drained"] > config.can_buses["bench"].max_buffer_frames
     assert result["side_effect_committed"] is True
     assert result["side_effect_status"] == "partial"
+    assert result["lease_state"] == "cleanup_required"
+
+
+def test_can_queue_drain_budget_excludes_the_pre_drain_audit_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = load_test_config(tmp_path, can_buses_yaml='can_buses:\n  bench:\n    adapter: "socketcan"\n    channel: "vcan0"\n    max_buffer_frames: 2\n')
+    service = CanBusService(config)
+    clock = {"now": 1000.0}
+
+    def slow_append(config_arg, log_path, record):
+        if record.get("event") == "queue_clear_start":
+            clock["now"] += CAN_DRAIN_TIMEOUT_S * 5
+        return append_jsonl_audited(config_arg, log_path, record)
+
+    monkeypatch.setattr("agentic_hil.can.append_jsonl_audited", slow_append)
+    monkeypatch.setattr("agentic_hil.can.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    class QueuedAdapter:
+        adapter_name = "fake"
+
+        def __init__(self) -> None:
+            self.frames = [1, 2, 3, 4, 5]
+            self.reads = 0
+
+        def read(self, max_frames: int, wait_timeout_s: float) -> dict:
+            self.reads += 1
+            batch = self.frames[:max_frames]
+            del self.frames[:max_frames]
+            return {"ok": True, "frames": [{"id": item} for item in batch]}
+
+        def status(self) -> dict:
+            return {"active": True}
+
+        def close(self) -> dict:
+            return {"safe_state_confirmed": True, "process_reaped": True}
+
+    adapter = QueuedAdapter()
+    session = CanBusSession("bench", config.can_buses["bench"], adapter, str(tmp_path / "can-slow-audit.jsonl"))
+    service.sessions["bench"] = session
+
+    result = service.session_start("bench", clear_rx_queue=True)
+
+    assert result["ok"] is True
+    assert adapter.frames == []
+    assert adapter.reads == 4
+
+
+def test_can_queue_drain_budget_still_bounds_adapter_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = load_test_config(tmp_path, can_buses_yaml='can_buses:\n  bench:\n    adapter: "socketcan"\n    channel: "vcan0"\n    max_buffer_frames: 2\n')
+    service = CanBusService(config)
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("agentic_hil.can.time", SimpleNamespace(monotonic=lambda: clock["now"]))
+
+    class SlowBusyAdapter:
+        adapter_name = "fake"
+
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def read(self, max_frames: int, wait_timeout_s: float) -> dict:
+            self.reads += 1
+            clock["now"] += CAN_DRAIN_TIMEOUT_S * 0.6
+            return {"ok": True, "frames": [{"id": 1}, {"id": 2}]}
+
+        def status(self) -> dict:
+            return {"active": True}
+
+    adapter = SlowBusyAdapter()
+    session = CanBusSession("bench", config.can_buses["bench"], adapter, str(tmp_path / "can-slow-adapter.jsonl"))
+    service.sessions["bench"] = session
+
+    result = service.session_start("bench", clear_rx_queue=True)
+
+    assert result["error_type"] == "can_queue_clear_limit"
+    assert adapter.reads == 2
     assert result["lease_state"] == "cleanup_required"
 
 


### PR DESCRIPTION
## What broke

`tests/test_hardening.py::test_active_can_session_drains_more_than_one_buffer_batch` fails intermittently on `Python 3.12 on windows-latest` (seen on run 30750717421) while master stays green for a dozen runs. It is a product bug, not a test bug.

`_drain_rx_queue` armed its deadline before the `queue_clear_start` audit write:

```python
deadline = time.monotonic() + CAN_DRAIN_TIMEOUT_S     # 1.0 s
audit_error = append_jsonl_audited(...)               # creates and appends a JSONL log on disk
...
for _ in range(CAN_DRAIN_BATCH_LIMIT):
    if time.monotonic() >= deadline:
        break
```

On a cold Windows runner, that first append creates the log file while a scanner holds it, and can take longer than the full budget. The loop then breaks on its first iteration with `drained = 0`, and `can_session_start` returns `ok: False` / `can_queue_clear_limit` for a receive queue the adapter was never asked about. The failure is a bad refusal on real hardware too, not only a red CI run.

## The fix

The drain budget is meant to bound time spent talking to the CAN adapter, not time spent writing the audit record, so the deadline is now armed after the audit write completes. A side effect worth naming: at least one adapter read now always happens per drain, so `frames_drained: 0` with `can_queue_clear_limit` is no longer reachable.

## Sibling paths

Checked; all three are already correct and unchanged:

- `PythonCanAdapterSession.read` arms its deadline inside the adapter call, so audit writes by the caller cannot consume it.
- `ComPortService.read_bytes` arms its deadline after argument validation, with no I/O between arming and the poll loop.
- `ComPortService._clear_buffers`, the COM equivalent of the drain, has no time budget at all.

`process.py`'s two wait loops arm their deadlines immediately before polling.

## Tests

Two regression tests replace `agentic_hil.can.time` with a fake clock:

- `test_can_queue_drain_budget_excludes_the_pre_drain_audit_write` advances the clock past the budget from inside the audit append and asserts the drain still completes all four reads. It fails on master with `assert False is True`.
- `test_can_queue_drain_budget_still_bounds_adapter_time` advances the clock from inside the adapter read and asserts the budget still cuts the drain short before the batch limit, so the fix did not just disarm the timeout.

`ruff check src tests evals tools` clean; full suite `606 passed, 27 skipped` on Windows (604 before the two new tests).
