### PR TITLE
build: keep the eval base image on Node 22, digests only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,13 @@ updates:
   # The eval container's base image is pinned by digest. Without this entry the
   # digest never moves, and a pin that never moves is a stale, vulnerable image
   # rather than a safe one.
+  #
+  # What this entry is for is digest freshness inside node:22, not moving to a
+  # new Node. The image is the runtime underneath the three agent CLIs the eval
+  # measures, so changing its major changes what the measurement means, and the
+  # first proposal this entry produced was a jump to node:25 - an odd-numbered
+  # line that never becomes LTS. Major bumps are a deliberate decision, made the
+  # same way the CLI pins are.
   - package-ecosystem: docker
     directory: "/evals/install/container"
     schedule:
@@ -40,6 +47,10 @@ updates:
       time: "06:45"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - version-update:semver-major
     groups:
       eval-container:
         patterns:


### PR DESCRIPTION
Follow-up to #58. The `docker` Dependabot entry I added there was meant to keep the pinned base image digest from going stale. Its first proposal was #62: `node:22-bookworm-slim` → `node:25-bookworm-slim`. That is not digest freshness, and it should not be merged.

## Why node:25 is the wrong direction here

- **22 is LTS, 25 is not.** Odd-numbered Node majors never become LTS; they get roughly six months of support. This swaps an LTS runtime for a short-lived one.
- **It changes what the eval measures.** The base image is the runtime underneath `codex`, `claude-code` and `opencode`. Moving its major moves the ground under all three, in a harness whose entire value is that results compare across runs.
- **It contradicts how this repo already treats the CLIs.** Their versions are pinned deliberately and `container_entrypoint.py` refuses to run when one silently drops a flag it depends on. The runtime beneath them deserves the same treatment.

## The change

Ignore `version-update:semver-major` for `node`. Major-only is sufficient here because the tag carries no minor or patch component — `22` is the whole version. Moving to the next LTS stays possible; it just has to be a decision rather than something that arrives on a Monday morning.

## One thing I could not confirm

Whether a `semver-major` ignore still lets **digest-only** updates through for an unchanged tag is not stated in the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), and [dependabot-core#1971](https://github.com/dependabot/dependabot-core/issues/1971) (the issue tracking exactly this) does not spell out the resulting behaviour either. So I am not claiming it.

What is certain is that this blocks the major jump. What to watch after merging:

- #62 should be closed automatically by Dependabot once the ignore rule covers it.
- If **no** digest-refresh PR ever appears for `node:22-bookworm-slim`, then the ignore rule is suppressing digest updates too, the entry is no longer doing its job, and the pin is quietly rotting — the exact failure this entry existed to prevent. In that case the digest needs either a narrower rule or a scheduled manual refresh.

I would rather flag that than have it discovered as a stale image months from now.

## Unrelated, for context

#61 (the github-actions group) is fine to merge: five patch-level bumps, all still SHA-pinned with version comments.