### PR TITLE
build: fix the Dependabot config that produced #64 and #65

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,17 @@ updates:
       time: "06:00"
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
+    # wrapt is not a dependency this project declares. It arrives through
+    # python-can, which requires wrapt~=1.10, so anything from 2.0 up cannot
+    # resolve. python-can 4.6.1 is the newest release and predates wrapt 2.0.0
+    # by two months, so there is no version to move to; the ceiling is upstream,
+    # not here. Mirror that ceiling instead of reopening the same unmergeable
+    # pull request every month, and keep 1.x patches flowing. Drop this once
+    # python-can ships a release that accepts wrapt 2.
+    ignore:
+      - dependency-name: "wrapt"
+        update-types:
+          - version-update:semver-major
     groups:
       python-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  # This entry covers pyproject.toml and the lock files under requirements/.
+  # The pip ecosystem already looks into a requirements/ subdirectory from the
+  # configured directory, so a second entry pointing at "/requirements" does not
+  # add coverage - it produces a duplicate pull request against the same file
+  # for every update, which is what it did.
   - package-ecosystem: pip
     directory: "/"
     schedule:
@@ -10,22 +15,6 @@ updates:
     open-pull-requests-limit: 5
     groups:
       python-dependencies:
-        patterns:
-          - "*"
-
-  # The hash-pinned lock files under requirements/ pin the release pipeline's
-  # build tooling. Without their own entry they never get updated, and a pinned
-  # dependency that never moves is a stale dependency.
-  - package-ecosystem: pip
-    directory: "/requirements"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:15"
-      timezone: Europe/Berlin
-    open-pull-requests-limit: 5
-    groups:
-      release-tooling:
         patterns:
           - "*"
 


### PR DESCRIPTION
Follow-up to #57. Dependabot opened #64 and #65 for the same `wrapt` bump. Two separate bugs in the config I added there, both fixed here.

## 1. The duplicate

Both PRs modified `requirements/dev.txt`, differing only in which group they claimed.

The pip ecosystem already looks into a `requirements/` subdirectory from its configured directory, so the pre-existing `/` entry was covering `requirements/` from the moment #57 created it. The `/requirements` entry added alongside it was pure duplication. #65 is the direct evidence: it came from the `/` entry's `python-dependencies` group and still modified `requirements/dev.txt`.

Two entries meant two pull requests per update against one file, and merging either would have left the other conflicting. Dropped the `/requirements` entry; `/` also covers `pyproject.toml`.

## 2. The bump was impossible, not merely unwanted

Both PRs failed all twelve matrix combinations:

```
ERROR: Cannot install -r requirements/dev.txt (line 406) and wrapt==2.3.0
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

`python-can==4.6.1` declares `wrapt~=1.10`, i.e. `>=1.10,<2`.

**Moving python-can up instead does not work** — 4.6.1 is already the newest release:

| python-can | wrapt constraint | released |
|---|---|---|
| 4.4.2 | `wrapt~=1.10` | 2024-06-23 |
| 4.5.0 | `wrapt~=1.10` | 2024-11-28 |
| 4.6.0 | `wrapt~=1.10` | 2025-08-08 |
| **4.6.1** (latest) | `wrapt~=1.10` | 2025-08-12 |

`wrapt 2.0.0` was published 2025-10-19, two months *after* python-can 4.6.1, and python-can has not released since. Upstream has never had the chance to adopt wrapt 2. The ceiling is not ours to raise.

`wrapt` is not a dependency this project declares — it is transitive. A hash-pinned lock lists every transitive package as its own line, so Dependabot cannot see that wrapt's bound belongs to python-can, and would reopen this same unmergeable PR every time wrapt releases.

So the config now mirrors the bound Dependabot cannot see: ignore `version-update:semver-major` for `wrapt` only. 1.x patches still flow. The comment in the file says to remove it once python-can ships a release accepting wrapt 2.

## Still open, deliberately not decided here

This is a targeted fix for one package with one documented upstream constraint, not a general answer. The underlying issue is that Dependabot only does whole-graph resolution for locks it recognises as `pip-compile` output, and these are generated by `uv pip compile --generate-hashes --universal` — deliberately, since `pip-compile` resolves per-platform and this lock serves 3 operating systems × 4 Python versions from one file.

If transitive bumps become a recurring nuisance beyond `wrapt`, the structural fix is moving the locks to `pip-compile` and giving up single-file universality. Not worth it for one package.

## Both wrapt PRs should be closed

They cannot be rebased into a working state. Dependabot should close them itself once this merges and the ignore rule covers them, the same way it closed #62 after #63.