### PR TITLE
chore: release Agentic HIL v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Safe embedded firmware development with hardware-in-the-loop targets via policy-gated MCP tools.",
       "source": "./plugins/agentic-hil",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-02
+
+An unattended loop no longer stops at every quarantine. The owning process clears the failure classes it can actually verify, and the audit records what verified them.
+
+### Added
+
+- **The owning process recovers its own quarantines.** A blocked hardware call attempts recovery before refusing: it reaps this owner's leftover debugger processes, verifies the safe state, writes a `recovery: machine_attested` report, and then runs. Previously a quarantine could only be cleared by a person running `agentic-hil recover` — for every class of fault, including ones no person can add information to, such as an OpenOCD process that died mid-cleanup.
+- **`recovery.auto_recover` policy** (`off`, `readonly`, `reset_halt`; defaults to `reset_halt`) with `recovery.max_attempts` (default 3) bounding attempts per incident. `readonly` reaps processes and re-reads the probe, which connects without resetting on every backend and therefore cannot alter the state it attests to. `reset_halt` additionally drives a reset-into-halt, which is what settles an unconfirmed flash, reset, or debug-session start. Set `readonly` if anything on the bench reacts to a target reset.
+- **`lease-status` reports why, not just that.** New `cleanup_reasons`, `auto_recoverable`, and `auto_recover_policy` fields answer whether to retry or fetch an operator. `cleanup_reasons` also travels on lease-carrying tool results and into the project record, so a second process sees it. The reason previously existed only inside the on-disk marker's `errors[]`, so classifying an incident meant opening state files under the state root.
+- **Machine-recovery provenance in reports:** `safe_state_predicate` (`readonly_probe` or `reset_halt`), `auto_recover_policy`, and `auto_recover_policy_source` (`config` or `default`). A config that never names the policy gets the default plus a one-time `warnings` entry the first time recovery resets its target.
+
+### Changed
+
+- One-shot debugger failures no longer share one undifferentiated quarantine reason. Read-only calls (`debugger_probes_list`, `probe_target`) raise `debugger_readonly_result_unconfirmed`, which a re-read settles; `flash_firmware` and `reset_target` keep `debugger_result_unconfirmed`, which needs the `reset_halt` predicate because either may have left the target running.
+- A one-shot call that quarantined kept its lease registered but unreachable, so nothing in the process could ever resolve it. The lease is now retained for recovery and released once the safe state is verified.
+- Under the default policy a failed `debug_start_session` load is settled by machine recovery instead of waiting for an operator. Recovery halts and never runs the target, so control is not handed back to a partially written image; flashing and running it again stays an explicit, permissioned act. Set `recovery.auto_recover: "readonly"` to keep the previous behaviour.
+
+Excluded from machine recovery regardless of policy: a broken audit (`*_audit_broken`), an incident adopted from an owner that died, a mix of reasons, a still-active sibling lease, an incident whose resources this owner no longer fully holds, and any bench without `allow_probe`. `reset_halt` degrades to `readonly` when the bound probe lacks `allow_reset`. The `machine_attested` report is written before the state transition, so a failed audit write aborts the recovery instead of silently unblocking hardware.
+
 ### Fixed
 
 - The CAN receive-queue drain budget bounds time spent talking to the adapter instead of also covering the `queue_clear_start` audit write that precedes it. The one-second deadline was armed before that write, so a slow first append — a cold runner creating the JSONL log while a scanner holds it — could consume the whole budget and break the loop before a single frame was read, failing `can_session_start` with `can_queue_clear_limit` and `frames_drained: 0` on a queue that was never touched.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix — all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.5.0"
+python -m pip install --user --upgrade "agentic-hil>=0.6.0"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -31,12 +31,12 @@ agentic-hil setup --help
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.5.0" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.5.0 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.5.0"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.6.0" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.6.0 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.6.0"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.5.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.5.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.6.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.6.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Do not store `uvx`, a workspace virtual environment, or a bare PATH command in `.mcp.json` or a user-level MCP registration. Run `agentic-hil setup --agent <agent>` for Claude Code, Codex, or OpenCode; it verifies the persistent executable and stores its absolute user-bin path. For another host, review that same persistent executable and configure its absolute path as described in [MCP host configuration](docs/mcp-hosts.md).
 

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Safe embedded firmware development with local hardware-in-the-loop targets, exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN).",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.5.0"
+  agentic_hil_version: "0.6.0"
 ---
 
 # Agentic HIL
@@ -86,11 +86,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.5.0"
+uv tool install --upgrade "agentic-hil==0.6.0"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.5.0`. If `uv` is unavailable or a
+The version check must report exactly `0.6.0`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. Then, from the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.5.0"
+version = "0.6.0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.5.0"
+  agentic_hil_version: "0.6.0"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
# Pull Request

## Summary

Release preparation for v0.6.0. No behaviour change of its own — it version-bumps every file the publish workflow cross-checks and dates the CHANGELOG section for what already landed on master.

The release theme is #67: an unattended loop no longer stops at every hardware quarantine. The owning process clears the failure classes it can verify, under a per-bench `recovery.auto_recover` policy, and the audit records which predicate attested the safe state.

Minor rather than patch, per the SemVer table in `docs/release-strategy.md`: `recovery:` is a compatible config addition, and `lease-status` and the machine-recovery report gained fields.

## User-visible Change

Version moves 0.5.0 → 0.6.0 in `pyproject.toml`, `src/agentic_hil/__init__.py`, both versions in `server.json`, `.claude-plugin/marketplace.json`, the plugin manifest, both packaged and plugin skill versions, and the `TROUBLESHOOTING.md` install pins.

`CHANGELOG.md` gets a dated `[0.6.0]` section covering the machine-recovery work from #67 and the previously unreleased CAN drain-budget fix.

## Validation

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes locally
- [x] `python -m build` and `twine check dist/*` were run if packaging changed
- [x] Docs were updated if behavior changed
- [ ] Tests were added or updated for behavior changes — not applicable, no behaviour change in this PR
- [ ] Demo screenshots/GIFs were updated if README onboarding or demo behavior changed — not applicable

`tools/check_shipped_references.py` passes; it is what caught that the `TROUBLESHOOTING.md` pins also carry the release version. The seven versions the publish workflow compares were checked locally and all read `0.6.0`. Built and checked as `agentic_hil-0.6.0`.

Test result: **620 passed, 8 failed** — the same pre-existing `skill_install` / `codex_skill_update` failures that touch the real user profile, unchanged from the baseline. Full runs on this machine need `APPDATA`/`LOCALAPPDATA` redirected to a freshly created directory, otherwise the project's own trust validator rejects the real `%APPDATA%` ACLs and ~312 unrelated tests fail.

## Hardware And Safety

- [x] No raw debugger command surface was added
- [x] No mass erase default behavior was added
- [x] Artifact root validation is preserved
- [x] COM access remains limited to configured `port_id` values
- [x] `permission_denied` behavior remains authoritative
- [x] Report/error fields remain structured for agents

Nothing in this PR touches hardware paths. The safety argument for the behaviour being released is in #67.

## Platform Impact

- [x] Windows paths and COM-port examples still make sense if setup behavior changed
- [x] Linux/macOS setup behavior is unchanged or documented

## Hardware Validation

**Not tested on real hardware.** The machine-recovery behaviour this release ships has only ever run against the fakes. Worth a bench run on the Nucleo-F446RE + ST-Link path before or right after cutting the tag: interrupt a real flash, confirm recovery clears the quarantine and leaves the target halted.

## Breaking Changes

None. `recovery:` is optional and every field defaults.

Worth knowing when upgrading: a config that does not name `recovery.auto_recover` gets `reset_halt`, which lets the owner reset the target unattended to settle an unconfirmed flash or reset. The first time that happens the report carries a one-time warning. A bench whose peripherals react to a reset should set `recovery.auto_recover: "readonly"`.
