### PR TITLE
ci: check version consistency before the merge, not after publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,29 @@ jobs:
       - name: Check distributions
         run: twine check dist/*
 
+  release_metadata:
+    name: Release metadata consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+
+      # Deliberately no `paths:` filter on the pull_request trigger. The failure
+      # this job exists to catch is a change that FORGETS one of the files that
+      # carry the version, and a paths filter keys on the files a pull request
+      # touched, so the one case it must catch is the case it would skip. It
+      # would also be a second hand-maintained enumeration of exactly the list
+      # that already drifted. The check is file reads and string comparisons;
+      # there is nothing worth saving.
+      - name: Check release version consistency
+        run: python tools/check_version_consistency.py
+
   audit:
     name: Production dependency audit
     runs-on: ubuntu-latest
@@ -97,6 +120,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - test
+      - release_metadata
       - audit
     if: ${{ always() }}
     steps:
@@ -105,6 +129,10 @@ jobs:
         run: |
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "Python test matrix finished with ${{ needs.test.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.release_metadata.result }}" != "success" ]]; then
+            echo "Release metadata consistency finished with ${{ needs.release_metadata.result }}"
             exit 1
           fi
           if [[ "${{ needs.audit.result }}" != "success" ]]; then

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,12 @@ permissions:
   contents: read
 
 jobs:
+  # Everything this job does that needs no tag also runs pre-merge, in the
+  # `Release metadata consistency` job of .github/workflows/ci.yml, from the same
+  # module. Publishing a release used to be the first moment a version mismatch
+  # became visible, which is the point of no return: a PyPI version cannot be
+  # re-uploaded. What is left here that pre-merge cannot do is `--release-tag`:
+  # the tag exists only once the release is created.
   validate_release:
     name: Validate release metadata
     if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch) }}
@@ -27,136 +33,12 @@ jobs:
       - name: Check shipped repository references
         run: python tools/check_shipped_references.py
 
+      # The same module the pull request already ran, plus the tag. Passing the
+      # tag is the only part of this that could not have run before the merge.
       - name: Verify release metadata and local contracts
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          python - <<'PY'
-          import ast
-          import json
-          import os
-          import pathlib
-          import re
-          import tomllib
-
-          root = pathlib.Path(".")
-          project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]
-          package_version = project["version"]
-          if project["name"] != "agentic-hil":
-              raise SystemExit("Python package name must be agentic-hil")
-          registry = json.loads((root / "server.json").read_text(encoding="utf-8"))
-          plugin = json.loads((root / "plugins/agentic-hil/.claude-plugin/plugin.json").read_text(encoding="utf-8"))
-          marketplace = json.loads((root / ".claude-plugin/marketplace.json").read_text(encoding="utf-8"))
-          changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
-          plugin_skill_path = root / "plugins/agentic-hil/skills/agentic-hil/SKILL.md"
-          plugin_skill = plugin_skill_path.read_text(encoding="utf-8")
-
-          init_tree = ast.parse((root / "src/agentic_hil/__init__.py").read_text(encoding="utf-8"))
-          init_version = next(
-              ast.literal_eval(node.value)
-              for node in init_tree.body
-              if isinstance(node, ast.Assign)
-              and any(isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets)
-          )
-
-          def skill_version(path: str) -> str:
-              content = (root / path).read_text(encoding="utf-8")
-              match = re.search(r'^\s*agentic_hil_version:\s*["\']([^"\']+)["\']\s*$', content, re.MULTILINE)
-              if match is None:
-                  raise SystemExit(f"{path} has no agentic_hil_version metadata")
-              return match.group(1)
-
-          if (root / "plugins/agentic-hil/.mcp.json").exists():
-              raise SystemExit("plugin must not persist a portable bare or transient MCP server command")
-          required_plugin_guidance = [
-              f'uv tool install --upgrade "agentic-hil=={package_version}"',
-              "agentic-hil setup --agent claude",
-          ]
-          if any(command not in plugin_skill for command in required_plugin_guidance):
-              raise SystemExit("plugin skill must pin the persistent package and delegate MCP registration to setup")
-
-          changelog_release = re.search(r"^## \[(\d+\.\d+\.\d+)\]", changelog, re.MULTILINE)
-          if changelog_release is None:
-              raise SystemExit("CHANGELOG.md has no released semantic version heading")
-
-          versions = {
-              "pyproject.toml": package_version,
-              "src/agentic_hil/__init__.py": init_version,
-              "server.json": registry["version"],
-              "server.json package": registry["packages"][0]["version"],
-              "plugin.json": plugin["version"],
-              "marketplace.json": marketplace["plugins"][0]["version"],
-              "CHANGELOG.md": changelog_release.group(1),
-              "packaged skill": skill_version("src/agentic_hil/skills/agentic-hil/SKILL.md"),
-              "plugin skill": skill_version("plugins/agentic-hil/skills/agentic-hil/SKILL.md"),
-          }
-          release_tag = os.environ.get("RELEASE_TAG")
-          if release_tag:
-              versions["release tag"] = release_tag.removeprefix("v")
-          if set(versions.values()) != {package_version}:
-              details = ", ".join(f"{source}={version}" for source, version in sorted(versions.items()))
-              raise SystemExit(f"release metadata versions differ: {details}")
-          if registry["packages"][0]["identifier"] != "agentic-hil":
-              raise SystemExit("server.json package identifier must be agentic-hil")
-
-          expected_registry = {
-              "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-              "name": "io.github.agentic-hil/agentic-hil",
-              "title": "Agentic HIL",
-              "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
-              "version": package_version,
-              "repository": {
-                  "url": "https://github.com/agentic-hil/agentic-hil",
-                  "source": "github",
-                  "id": "1278450589",
-              },
-              "websiteUrl": "https://github.com/agentic-hil/agentic-hil",
-              "packages": [
-                  {
-                      "registryType": "pypi",
-                      "registryBaseUrl": "https://pypi.org",
-                      "identifier": "agentic-hil",
-                      "version": package_version,
-                      "runtimeHint": "uvx",
-                      "transport": {"type": "stdio"},
-                      "packageArguments": [{"type": "positional", "value": "mcp-stdio"}],
-                  }
-              ],
-          }
-          if registry != expected_registry:
-              raise SystemExit("server.json differs from the locally validated release contract")
-
-          expected_plugin = {
-              "name": "agentic-hil",
-              "displayName": "Agentic Hardware-in-the-Loop",
-              "version": package_version,
-              "description": "Safe embedded firmware development with local hardware-in-the-loop targets, exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN).",
-              "author": {"name": "Hannes Pauli"},
-              "repository": "https://github.com/agentic-hil/agentic-hil",
-              "license": "Apache-2.0",
-              "keywords": ["embedded", "firmware", "hardware-in-the-loop", "mcp", "stm32", "openocd"],
-          }
-          if plugin != expected_plugin:
-              raise SystemExit("plugin.json differs from the locally validated release contract")
-
-          expected_marketplace = {
-              "name": "agentic-hil",
-              "description": "Official Claude Code plugins for Agentic Hardware-in-the-Loop.",
-              "owner": {"name": "agentic-hil"},
-              "plugins": [
-                  {
-                      "name": "agentic-hil",
-                      "displayName": "Agentic Hardware-in-the-Loop",
-                      "description": "Safe embedded firmware development with hardware-in-the-loop targets via policy-gated MCP tools.",
-                      "source": "./plugins/agentic-hil",
-                      "version": package_version,
-                      "license": "Apache-2.0",
-                  }
-              ],
-          }
-          if marketplace != expected_marketplace:
-              raise SystemExit("marketplace.json differs from the locally validated release contract")
-          PY
+        run: python tools/check_version_consistency.py --release-tag "$RELEASE_TAG"
 
   publish:
     needs: validate_release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,4 +54,4 @@ Agentic HIL is designed to let agents perform hardware actions through configure
 
 ## Releases
 
-See [docs/release-strategy.md](docs/release-strategy.md). In short: update `CHANGELOG.md` and the `pyproject.toml` version together, let CI pass, then create a GitHub Release with a `vX.Y.Z` tag that exactly matches the package version — the publish workflow validates the tag, builds, and publishes to PyPI through trusted publishing.
+See [docs/release-strategy.md](docs/release-strategy.md). In short: bump the version in every position `python tools/check_version_consistency.py --list` prints — do not work from a list you remember, that is what drifted — let CI pass, then create a GitHub Release with a `vX.Y.Z` tag that exactly matches the package version. The same check runs on every pull request, so a position left behind is red before the release exists; the publish workflow re-runs it with the tag, builds, and publishes to PyPI through trusted publishing.

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -32,7 +32,7 @@ links to relevant docs
 
 ## Distribution Channels
 
-PyPI first. Publishing runs through GitHub Actions trusted publishing with OIDC (`.github/workflows/workflow.yml`) — no long-lived PyPI API tokens. Before publishing, the workflow validates the release tag and the synchronized package, registry, marketplace, plugin, changelog, and bundled-skill contracts. It then builds sdist and wheel and validates them with twine.
+PyPI first. Publishing runs through GitHub Actions trusted publishing with OIDC (`.github/workflows/workflow.yml`) — no long-lived PyPI API tokens. The synchronized package, registry, marketplace, plugin, changelog, install-eval, troubleshooting, and bundled-skill contracts are already settled before the merge by `tools/check_version_consistency.py` in CI; the release job runs the same module again with `--release-tag`, which is the one comparison a pull request cannot make. It then builds sdist and wheel and validates them with twine.
 
 After PyPI accepts a release, the same workflow verifies the package's `mcp-name` ownership marker and publishes `server.json` to the preview MCP Registry through GitHub Actions OIDC. No MCP Registry secret is stored. The release tag, Python package version, top-level server version, and package version in `server.json` must match exactly. The registry is an additional discovery channel; the documented local CLI and MCP configuration path remains authoritative and host-independent.
 
@@ -47,17 +47,54 @@ Later packaging candidates are Homebrew, Scoop or WinGet, and conda-forge — ad
 Before creating a release:
 
 ```text
-1. Update `pyproject.toml`, `src/agentic_hil/__init__.py`, `server.json`, `CHANGELOG.md`, `.claude-plugin/marketplace.json`, the Claude plugin manifest, and both packaged/plugin skill versions together.
-2. Run ruff check src tests examples and pytest.
+1. Bump the version in every position `python tools/check_version_consistency.py --list` prints, then run `python tools/check_version_consistency.py` until it is silent.
+2. Run ruff check src tests evals tools and pytest.
 3. Run python -m build (or uv build) and inspect the packaged files.
-4. Merge to master and let the CI matrix pass.
+4. Open a pull request and let Required CI pass; the same check runs there, so a forgotten position is red before a release exists.
 5. Create a GitHub Release with a strict SemVer vX.Y.Z tag that exactly matches pyproject.toml.
-6. Let the publish workflow validate every local release contract before it builds, checks, and publishes to PyPI.
+6. Let the publish workflow re-run the same check with the release tag before it builds, checks, and publishes to PyPI.
 7. Let the workflow verify the PyPI ownership marker and publish the matching `server.json` through GitHub OIDC.
 8. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
 9. Verify the release appears as `io.github.agentic-hil/agentic-hil` in the MCP Registry API.
 10. Start from GitHub auto-generated release notes, then edit for clarity.
 ```
+
+## What the Release Gate Checks, and When
+
+Step 1 deliberately names no files. An enumeration kept by hand in this document
+drifted: it listed seven positions while the release carried a version in twelve
+files, and the two install-eval matrices it omitted sat at a stale version for
+two releases, aborting every run before it started. The list now lives in
+`tools/check_version_consistency.py`, which is the check that enforces it, so
+this document cannot fall behind it. `--list` prints every position and what
+carries the version there; a file that starts carrying the version and is named
+in neither the check nor its declared exceptions is itself an error.
+
+That check is the single enforcement point for version agreement. It reads files
+and compares strings — no secret, no OIDC, no tag — so it runs pre-merge as the
+`Release metadata consistency` job of `.github/workflows/ci.yml`, on every push
+and every pull request, with no `paths:` filter: the failure it exists to catch
+is a change that *forgets* a file, and a paths filter keys on the files a pull
+request touched. `Required CI` depends on it, so a version that does not agree
+with itself cannot reach `master`.
+
+Three things still cannot be established before the merge, and no rearrangement
+of the workflow changes that:
+
+```text
+release tag vs pyproject.toml   the tag does not exist until the release is created;
+                                checked at release with --release-tag, and again by
+                                publish-mcp-registry before it publishes server.json
+PyPI mcp-name ownership marker  needs the artifact PyPI has accepted
+MCP Registry acceptance         needs the published PyPI release to verify against
+```
+
+Everything else the release job used to discover for the first time at
+`release: published` — every position `--list` prints, the three JSON manifests
+byte for byte against their contracts, and the sweep that refuses a file
+carrying the version that no check covers — is now settled before the merge.
+That matters because publishing is the point of no return: a PyPI version
+cannot be re-uploaded.
 
 ## Repository Protection
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import ast
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from check_version_consistency import (  # noqa: E402
+    UNTRACKED_MENTIONS,
+    contract_problems,
+    locations,
+    main,
+    package_version,
+    problems,
+    render_list,
+    uncovered_files,
+    version_problems,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CHECK = "tools/check_version_consistency.py"
+
+
+def test_the_gate_runs_on_every_python_this_project_supports() -> None:
+    """tomllib is stdlib only from 3.11 and this project still supports 3.10.
+
+    The version gate now blocks the merge, so a gate that cannot import on a
+    matrix leg would block every merge on that leg instead of catching anything.
+    """
+    source = (REPOSITORY_ROOT / CHECK).read_text(encoding="utf-8")
+    modules = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module.split(".")[0])
+
+    assert "tomllib" not in modules
+    assert modules <= {"__future__", "ast", "json", "re", "sys", "dataclasses", "pathlib"}, sorted(modules)
+
+
+def test_this_tree_agrees_with_itself() -> None:
+    assert main([str(REPOSITORY_ROOT)]) == 0
+
+
+def test_the_release_carries_its_version_where_the_release_that_exposed_this_carried_it() -> None:
+    """Every position issue hardci-hq#75 counted, including the five it found missing."""
+    covered = {location.path for location in locations(REPOSITORY_ROOT)}
+
+    assert covered >= {
+        "pyproject.toml",
+        "src/agentic_hil/__init__.py",
+        "server.json",
+        "plugins/agentic-hil/.claude-plugin/plugin.json",
+        ".claude-plugin/marketplace.json",
+        "CHANGELOG.md",
+        "src/agentic_hil/skills/agentic-hil/SKILL.md",
+        "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
+        # The five the hand-maintained checklist never named. Both matrices sat
+        # at 0.4.0 for two releases and aborted every run before it started.
+        "TROUBLESHOOTING.md",
+        "evals/install/matrix.example.json",
+        "evals/install/matrix.full.json",
+        "evals/install/README.md",
+    }
+
+
+def test_every_stated_position_actually_carries_a_version() -> None:
+    version = package_version(REPOSITORY_ROOT)
+    for location in locations(REPOSITORY_ROOT):
+        assert location.versions, f"{location.path} states no version"
+        assert set(location.versions) == {version}, location
+
+
+def test_the_troubleshooting_pins_are_all_of_them() -> None:
+    """Five `agentic-hil>=` pins, not the one somebody happened to remember."""
+    pins = next(
+        location for location in locations(REPOSITORY_ROOT) if location.path == "TROUBLESHOOTING.md"
+    ).versions
+
+    assert len(pins) == 5, pins
+
+
+def test_the_checklist_points_at_the_check_instead_of_repeating_it() -> None:
+    """The list in docs drifted once. It is no longer kept there."""
+    strategy = (REPOSITORY_ROOT / "docs" / "release-strategy.md").read_text(encoding="utf-8")
+
+    assert CHECK in strategy
+    assert "--list" in strategy
+    # The old enumeration, which named seven of twelve positions.
+    assert "and both packaged/plugin skill versions together" not in strategy
+
+
+def test_the_pull_request_job_runs_the_check_without_a_paths_filter() -> None:
+    """A paths filter would skip exactly the pull request that forgets a file."""
+    ci = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    release = (REPOSITORY_ROOT / ".github" / "workflows" / "workflow.yml").read_text(encoding="utf-8")
+
+    assert f"python {CHECK}" in ci
+    assert "release_metadata" in ci
+    assert "pull_request" in ci
+    # A `paths:` key, not the word in the comment that explains its absence.
+    assert re.search(r"^\s+paths:", ci, re.MULTILINE) is None
+    # Required CI is the branch-protection status check; the new job has to be
+    # part of it or it blocks nothing.
+    assert "needs.release_metadata.result" in ci
+    # The release job runs the same module, and only the tag stays behind.
+    assert f"python {CHECK} --release-tag" in release
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A copy of the tree the check reads, cheap enough to break on purpose."""
+    root = tmp_path / "repository"
+    root.mkdir()
+    for relative in {location.path for location in locations(REPOSITORY_ROOT)}:
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPOSITORY_ROOT / relative, destination)
+    return root
+
+
+def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
+    assert version_problems(tree) == []
+    assert contract_problems(tree) == []
+    assert uncovered_files(tree) == []
+
+
+@pytest.mark.parametrize(
+    ("relative", "replace", "names"),
+    [
+        # pyproject.toml is the reference every other position is compared with,
+        # so moving it alone reports the other eleven rather than itself. Either
+        # way the tree is refused, which is what a release depends on.
+        (
+            "pyproject.toml",
+            lambda text, version: text.replace(f'version = "{version}"', 'version = "9.9.9"', 1),
+            "but this release is 9.9.9",
+        ),
+        (
+            "src/agentic_hil/__init__.py",
+            lambda text, version: text.replace(f'__version__ = "{version}"', '__version__ = "9.9.9"'),
+            "src/agentic_hil/__init__.py",
+        ),
+        (
+            "server.json",
+            lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"', 1),
+            "server.json",
+        ),
+        (
+            "plugins/agentic-hil/.claude-plugin/plugin.json",
+            lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"'),
+            "plugins/agentic-hil/.claude-plugin/plugin.json",
+        ),
+        (
+            ".claude-plugin/marketplace.json",
+            lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"'),
+            ".claude-plugin/marketplace.json",
+        ),
+        (
+            "CHANGELOG.md",
+            lambda text, version: text.replace(f"## [{version}]", "## [9.9.9]", 1),
+            "CHANGELOG.md",
+        ),
+        (
+            "src/agentic_hil/skills/agentic-hil/SKILL.md",
+            lambda text, version: text.replace(version, "9.9.9", 1),
+            "src/agentic_hil/skills/agentic-hil/SKILL.md",
+        ),
+        (
+            "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
+            lambda text, version: text.replace(f"agentic-hil=={version}", "agentic-hil==9.9.9"),
+            "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
+        ),
+        (
+            "TROUBLESHOOTING.md",
+            lambda text, version: text.replace(f"agentic-hil>={version}", "agentic-hil>=9.9.9", 1),
+            "TROUBLESHOOTING.md",
+        ),
+        (
+            "evals/install/matrix.example.json",
+            lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
+            "evals/install/matrix.example.json",
+        ),
+        (
+            "evals/install/matrix.full.json",
+            lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
+            "evals/install/matrix.full.json",
+        ),
+        (
+            "evals/install/README.md",
+            lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
+            "evals/install/README.md",
+        ),
+    ],
+)
+def test_one_position_out_of_step_fails(tree: Path, relative: str, replace, names: str) -> None:
+    """The proof. Break the version in exactly one file and the check goes red.
+
+    Every position in turn, because a check that covers eleven of twelve is the
+    thing this replaced.
+    """
+    version = package_version(tree)
+    path = tree / relative
+    broken = replace(path.read_text(encoding="utf-8"), version)
+    assert broken != path.read_text(encoding="utf-8"), f"the test did not actually change {relative}"
+    path.write_text(broken, encoding="utf-8")
+
+    found = problems(tree)
+
+    assert found, relative
+    assert any(names in problem for problem in found), found
+
+
+def test_a_version_the_release_notes_mention_in_prose_is_not_a_mismatch(tree: Path) -> None:
+    """CHANGELOG.md keeps every past release. Only its newest heading tracks."""
+    changelog = tree / "CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8") + "\n## [0.1.0] - 2020-01-01\n\nThe first one.\n",
+        encoding="utf-8",
+    )
+
+    assert version_problems(tree) == []
+
+
+def test_a_new_home_for_the_version_cannot_appear_unnoticed(tree: Path) -> None:
+    """The half that keeps the list from drifting again.
+
+    Extending the checklist was never enough: what failed was that a thirteenth
+    file could start carrying the version with nothing to notice.
+    """
+    version = package_version(tree)
+    (tree / "docs").mkdir(parents=True, exist_ok=True)
+    (tree / "docs" / "installation.md").write_text(f'pip install "agentic-hil=={version}"\n', encoding="utf-8")
+
+    found = uncovered_files(tree)
+
+    assert found
+    assert "docs/installation.md" in found[0]
+    assert CHECK in found[0]
+
+
+def test_a_deliberate_mention_is_declared_rather_than_forgotten(tree: Path) -> None:
+    """`AI_AGENT_QUICKSTART.md` states a capability floor, not this release.
+
+    It is exempt because it says so in UNTRACKED_MENTIONS with a reason, which is
+    a claim a reviewer can argue with. A file merely left out of the list is not.
+    """
+    version = package_version(tree)
+    for relative in UNTRACKED_MENTIONS:
+        (tree / relative).parent.mkdir(parents=True, exist_ok=True)
+        (tree / relative).write_text(f"{version} or newer is required\n", encoding="utf-8")
+
+    assert uncovered_files(tree) == []
+    assert "AI_AGENT_QUICKSTART.md" in UNTRACKED_MENTIONS
+
+
+def test_a_version_inside_a_longer_number_is_not_a_mention(tree: Path) -> None:
+    version = package_version(tree)
+    major, minor, patch = version.split(".")
+    (tree / "docs").mkdir(parents=True, exist_ok=True)
+    (tree / "docs" / "numbers.md").write_text(f"1{version} and {major}.{minor}.{patch}9\n", encoding="utf-8")
+
+    assert uncovered_files(tree) == []
+
+
+@pytest.mark.parametrize("tag", ["v9.9.9", "9.9.9"])
+def test_a_tag_that_is_not_this_version_fails(tree: Path, tag: str) -> None:
+    found = version_problems(tree, release_tag=tag)
+
+    assert found
+    assert "release tag" in found[0]
+
+
+@pytest.mark.parametrize("tag", ["", None])
+def test_no_tag_is_not_a_failure(tree: Path, tag: str | None) -> None:
+    """A pull request has no tag. That is the whole point of running there."""
+    assert version_problems(tree, release_tag=tag) == []
+
+
+def test_the_release_tag_is_accepted_with_and_without_its_v(tree: Path) -> None:
+    version = package_version(tree)
+
+    assert version_problems(tree, release_tag=f"v{version}") == []
+    assert version_problems(tree, release_tag=version) == []
+
+
+@pytest.mark.parametrize(
+    ("relative", "mutate"),
+    [
+        (
+            "server.json",
+            lambda document: document.__setitem__("websiteUrl", "https://example.invalid"),
+        ),
+        (
+            "plugins/agentic-hil/.claude-plugin/plugin.json",
+            lambda document: document.__setitem__("license", "MIT"),
+        ),
+        (
+            ".claude-plugin/marketplace.json",
+            lambda document: document["plugins"][0].__setitem__("source", "./elsewhere"),
+        ),
+    ],
+)
+def test_a_published_manifest_that_drifts_from_its_contract_fails(tree: Path, relative: str, mutate) -> None:
+    """These reach a registry or a plugin host, and cannot be withdrawn either."""
+    path = tree / relative
+    document = json.loads(path.read_text(encoding="utf-8"))
+    mutate(document)
+    path.write_text(json.dumps(document, indent=2), encoding="utf-8")
+
+    found = contract_problems(tree)
+
+    assert found
+    assert "release contract" in found[0]
+
+
+def test_the_package_must_keep_its_name(tree: Path) -> None:
+    pyproject = tree / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text(encoding="utf-8").replace('name = "agentic-hil"', 'name = "agentic_hil"', 1),
+        encoding="utf-8",
+    )
+
+    assert any("package name" in problem for problem in contract_problems(tree))
+
+
+def test_a_persisted_plugin_mcp_command_is_refused(tree: Path) -> None:
+    (tree / "plugins" / "agentic-hil" / ".mcp.json").write_text("{}", encoding="utf-8")
+
+    assert any("MCP server command" in problem for problem in contract_problems(tree))
+
+
+def test_the_printed_list_names_every_position_and_its_count() -> None:
+    listing = render_list(REPOSITORY_ROOT)
+    version = package_version(REPOSITORY_ROOT)
+    carried = locations(REPOSITORY_ROOT)
+
+    assert version in listing
+    for location in carried:
+        assert location.path in listing
+        assert location.carries in listing
+    for path in UNTRACKED_MENTIONS:
+        assert path in listing
+    counted = re.search(r"in (\d+) files, (\d+) occurrences", listing)
+    assert counted is not None
+    assert int(counted.group(1)) == len(carried)
+    assert int(counted.group(2)) == sum(len(location.versions) for location in carried)
+
+
+def test_an_unknown_option_is_refused() -> None:
+    with pytest.raises(SystemExit):
+        main(["--publish"])

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -1,0 +1,467 @@
+"""Refuse a tree whose release version does not agree with itself.
+
+A version lives in more places than anyone remembers. The release checklist in
+`docs/release-strategy.md` named seven positions; the release that exposed this
+carried a version in twelve files. The two install-eval matrices were among the
+five nobody had written down, and `validate_source_version` in
+`evals/install/runner.py` raises before a run starts, so both matrices —
+including the runner CLI's own default — aborted on every tree newer than the
+0.4.0 they still pinned. That went unnoticed across two releases, because the
+only thing that enforced version agreement ran on `release: published`: after
+the point of no return, since a PyPI version cannot be re-uploaded.
+Implements hardci-hq#74 and hardci-hq#75.
+
+So this is one module rather than a step in a release job. It reads files and
+compares strings — no secret, no OIDC, no tag — which is exactly the shape that
+belongs on a pull request. `.github/workflows/ci.yml` runs it on every push and
+pull request; `.github/workflows/workflow.yml` runs the same code again at
+release with `--release-tag`, the one comparison that genuinely needs a tag.
+
+`locations` below is the list. It is not a copy of the checklist: it is the
+check, and `--list` prints it, so `docs/release-strategy.md` can point here
+instead of repeating an enumeration that drifts. `uncovered_files` closes the
+other half — any file carrying the release version that no entry accounts for
+is an error, so a new home for the version cannot appear unnoticed.
+
+tomllib is deliberately absent: it is stdlib only from 3.11 and this project
+still supports 3.10, so importing it would make the gate itself the thing that
+fails on a matrix leg the developer machine never runs.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+RELEASE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+# An optional leading "v" so a tag pin is seen, and no word character or dot on
+# either side so "1.2.3" is not read out of "11.2.3" or "1.2.30".
+SEMVER = re.compile(r"(?<![\w.])v?(\d+\.\d+\.\d+)(?![\w.])")
+PYPROJECT_TABLE = re.compile(r"^\[(?P<table>[^\]]+)\]\s*$")
+TOML_STRING = re.compile(r"""^(?P<key>[A-Za-z0-9_-]+)\s*=\s*["'](?P<value>[^"']*)["']\s*$""")
+SKILL_METADATA_VERSION = re.compile(r"""^\s*agentic_hil_version:\s*["']([^"']+)["']\s*$""", re.MULTILINE)
+CHANGELOG_RELEASE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+EXPECTED_VERSION_FIELD = re.compile(r"""["']expected_version["']\s*:\s*["']([^"']+)["']""")
+
+# The sweep walks the working tree, so it meets whatever else lives there.
+SKIPPED_DIRECTORIES = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        ".testenv",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "__pycache__",
+        "node_modules",
+        "build",
+        "dist",
+        "htmlcov",
+        ".tox",
+        # Hash-pinned third-party locks. A dependency that happens to sit at our
+        # version number says nothing about our release, and nobody hand-edits
+        # these to prepare one.
+        "requirements",
+    }
+)
+# Generated output and local agent state, by path rather than by name so that
+# ".claude-plugin" — which is content — is not caught with ".claude".
+SKIPPED_PATHS = frozenset({".agentic-hil", ".claude", "evals/install/artifacts"})
+SKIPPED_NAMES = frozenset({"package-lock.json", "uv.lock", "poetry.lock"})
+SKIPPED_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".ico", ".whl", ".gz", ".zip"})
+MAX_SWEPT_BYTES = 4_000_000
+
+# A file may carry the release version without tracking it, but it has to say so
+# here, with the reason. An entry is a claim someone can argue with; a file
+# quietly left out of the list is how this failed the first time.
+UNTRACKED_MENTIONS: dict[str, str] = {
+    # AI_AGENT_QUICKSTART.md pins ">=0.4.0" as the release that first shipped
+    # `setup`. It is a capability floor and must not follow the release: raising
+    # it would reject installations that are new enough.
+    "AI_AGENT_QUICKSTART.md": "capability floor, deliberately not the current release",
+}
+
+
+@dataclass(frozen=True)
+class Location:
+    """One place that carries the release version."""
+
+    path: str
+    carries: str
+    versions: tuple[str, ...] = ()
+
+
+def _read(root: Path, relative: str) -> str:
+    return (root / relative).read_text(encoding="utf-8")
+
+
+def _project_table(root: Path) -> dict[str, str]:
+    """The `[project]` table of pyproject.toml, as far as flat strings go.
+
+    Enough for `name` and `version`, and it costs no TOML parser on 3.10.
+    """
+    table: dict[str, str] = {}
+    inside = False
+    for line in _read(root, "pyproject.toml").splitlines():
+        header = PYPROJECT_TABLE.match(line)
+        if header is not None:
+            inside = header.group("table") == "project"
+            continue
+        if not inside:
+            continue
+        entry = TOML_STRING.match(line)
+        if entry is not None:
+            table[entry.group("key")] = entry.group("value")
+    return table
+
+
+def package_version(root: Path) -> str:
+    version = _project_table(root).get("version")
+    if version is None or not RELEASE_VERSION.match(version):
+        raise SystemExit("pyproject.toml [project] declares no strict SemVer version")
+    return version
+
+
+def _init_version(root: Path) -> str:
+    tree = ast.parse(_read(root, "src/agentic_hil/__init__.py"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets
+        ):
+            return str(ast.literal_eval(node.value))
+    raise SystemExit("src/agentic_hil/__init__.py declares no __version__")
+
+
+def _skill_metadata_version(root: Path, relative: str) -> str:
+    match = SKILL_METADATA_VERSION.search(_read(root, relative))
+    if match is None:
+        raise SystemExit(f"{relative} has no agentic_hil_version metadata")
+    return match.group(1)
+
+
+def _skill_body_versions(root: Path, relative: str) -> tuple[str, ...]:
+    """Every version the skill states in prose or in a command.
+
+    A skill is installed into an agent's home and read by something that cannot
+    check it, so the pinned install command and the version the agent is told to
+    expect have to be this release. Exhaustive on purpose: the install command
+    was pinned by a substring test that a second, stale mention slipped past.
+    """
+    body = SKILL_METADATA_VERSION.sub("", _read(root, relative))
+    return tuple(match.group(1) for match in SEMVER.finditer(body))
+
+
+def _requirement_pins(root: Path, relative: str) -> tuple[str, ...]:
+    """Every `agentic-hil>=X.Y.Z` or `agentic-hil==X.Y.Z` in a document."""
+    text = _read(root, relative)
+    return tuple(re.findall(r"agentic-hil(?:>=|==)(\d+\.\d+\.\d+)", text))
+
+
+def _changelog_release(root: Path) -> str:
+    match = CHANGELOG_RELEASE.search(_read(root, "CHANGELOG.md"))
+    if match is None:
+        raise SystemExit("CHANGELOG.md has no released semantic version heading")
+    return match.group(1)
+
+
+def _json_document(root: Path, relative: str) -> dict:
+    return json.loads(_read(root, relative))
+
+
+def locations(root: Path) -> list[Location]:
+    """Every place the release version has to appear, and what carries it there.
+
+    This is the list the release checklist used to keep by hand. Keeping it here
+    means the documentation cannot fall behind the check, because it is the
+    check.
+    """
+    registry = _json_document(root, "server.json")
+    plugin = _json_document(root, "plugins/agentic-hil/.claude-plugin/plugin.json")
+    marketplace = _json_document(root, ".claude-plugin/marketplace.json")
+    example_matrix = _json_document(root, "evals/install/matrix.example.json")
+    full_matrix = _json_document(root, "evals/install/matrix.full.json")
+
+    return [
+        Location("pyproject.toml", "[project] version: the distribution version", (package_version(root),)),
+        Location("src/agentic_hil/__init__.py", "__version__: what the CLI and MCP server report", (_init_version(root),)),
+        Location(
+            "server.json",
+            "version and packages[0].version: the MCP Registry entry",
+            (str(registry["version"]), str(registry["packages"][0]["version"])),
+        ),
+        Location(
+            "plugins/agentic-hil/.claude-plugin/plugin.json",
+            "version: the Claude Code plugin manifest",
+            (str(plugin["version"]),),
+        ),
+        Location(
+            ".claude-plugin/marketplace.json",
+            "plugins[0].version: the marketplace entry",
+            (str(marketplace["plugins"][0]["version"]),),
+        ),
+        Location("CHANGELOG.md", "the newest ## [X.Y.Z] heading", (_changelog_release(root),)),
+        Location(
+            "src/agentic_hil/skills/agentic-hil/SKILL.md",
+            "agentic_hil_version metadata, and every version stated in the body",
+            (
+                _skill_metadata_version(root, "src/agentic_hil/skills/agentic-hil/SKILL.md"),
+                *_skill_body_versions(root, "src/agentic_hil/skills/agentic-hil/SKILL.md"),
+            ),
+        ),
+        Location(
+            "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
+            "agentic_hil_version metadata, the pinned install command, and every version stated in the body",
+            (
+                _skill_metadata_version(root, "plugins/agentic-hil/skills/agentic-hil/SKILL.md"),
+                *_skill_body_versions(root, "plugins/agentic-hil/skills/agentic-hil/SKILL.md"),
+            ),
+        ),
+        Location(
+            "TROUBLESHOOTING.md",
+            "every agentic-hil>= install pin the fix instructions hand a reader",
+            _requirement_pins(root, "TROUBLESHOOTING.md"),
+        ),
+        Location(
+            "evals/install/matrix.example.json",
+            "target.expected_version: the install-eval runner refuses to start when it disagrees",
+            (str(example_matrix["target"]["expected_version"]),),
+        ),
+        Location(
+            "evals/install/matrix.full.json",
+            "target.expected_version: the install-eval runner refuses to start when it disagrees",
+            (str(full_matrix["target"]["expected_version"]),),
+        ),
+        Location(
+            "evals/install/README.md",
+            "expected_version in the documented matrix example a reader copies",
+            tuple(EXPECTED_VERSION_FIELD.findall(_read(root, "evals/install/README.md"))),
+        ),
+    ]
+
+
+def version_problems(root: Path, release_tag: str | None = None) -> list[str]:
+    """Every version source that disagrees with pyproject.toml."""
+    version = package_version(root)
+    found = []
+    for location in locations(root):
+        if not location.versions:
+            found.append(f"{location.path} carries no version, but {location.carries} was expected")
+            continue
+        for stated in location.versions:
+            if stated != version:
+                found.append(f"{location.path} states {stated}, but this release is {version} ({location.carries})")
+    if release_tag:
+        tagged = release_tag[1:] if release_tag.startswith("v") else release_tag
+        if tagged != version:
+            found.append(f"release tag {release_tag} does not match pyproject.toml {version}")
+    return found
+
+
+def _swept_files(root: Path) -> list[Path]:
+    found: list[Path] = []
+
+    def walk(directory: Path) -> None:
+        for entry in sorted(directory.iterdir()):
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                relative = entry.relative_to(root).as_posix()
+                if entry.name in SKIPPED_DIRECTORIES or entry.name.endswith(".egg-info"):
+                    continue
+                if relative in SKIPPED_PATHS:
+                    continue
+                walk(entry)
+            elif entry.is_file():
+                if entry.name in SKIPPED_NAMES or entry.suffix.lower() in SKIPPED_SUFFIXES:
+                    continue
+                if entry.stat().st_size > MAX_SWEPT_BYTES:
+                    continue
+                found.append(entry)
+
+    walk(root)
+    return found
+
+
+def uncovered_files(root: Path, version: str | None = None) -> list[str]:
+    """Files that carry the release version and no entry in `locations` claims.
+
+    This is what makes the list underivable from memory: adding a thirteenth
+    home for the version without adding it here turns the build red, and the
+    message says where.
+    """
+    version = version or package_version(root)
+    carries = re.compile(rf"(?<![\w.])v?{re.escape(version)}(?![\w.])")
+    covered = {location.path for location in locations(root)}
+    found = []
+    for path in _swept_files(root):
+        relative = path.relative_to(root).as_posix()
+        if relative in covered or relative in UNTRACKED_MENTIONS:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if carries.search(text):
+            found.append(
+                f"{relative} carries version {version} but no check covers it: "
+                f"add it to locations() in tools/check_version_consistency.py, "
+                f"or to UNTRACKED_MENTIONS with the reason it must not track the release"
+            )
+    return found
+
+
+def contract_problems(root: Path) -> list[str]:
+    """The three published manifests, byte for byte against the release contract.
+
+    A version that agrees with itself is not enough: these documents are read by
+    registries and plugin hosts, and a field that silently changes shape is a
+    published mistake nobody can withdraw.
+    """
+    version = package_version(root)
+    found = []
+
+    if (root / "plugins/agentic-hil/.mcp.json").exists():
+        found.append("plugin must not persist a portable bare or transient MCP server command")
+
+    project = _project_table(root)
+    if project.get("name") != "agentic-hil":
+        found.append("Python package name must be agentic-hil")
+
+    plugin_skill = _read(root, "plugins/agentic-hil/skills/agentic-hil/SKILL.md")
+    required_plugin_guidance = [
+        f'uv tool install --upgrade "agentic-hil=={version}"',
+        "agentic-hil setup --agent claude",
+    ]
+    if any(command not in plugin_skill for command in required_plugin_guidance):
+        found.append("plugin skill must pin the persistent package and delegate MCP registration to setup")
+
+    registry = _json_document(root, "server.json")
+    expected_registry = {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name": "io.github.agentic-hil/agentic-hil",
+        "title": "Agentic HIL",
+        "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+        "version": version,
+        "repository": {
+            "url": "https://github.com/agentic-hil/agentic-hil",
+            "source": "github",
+            "id": "1278450589",
+        },
+        "websiteUrl": "https://github.com/agentic-hil/agentic-hil",
+        "packages": [
+            {
+                "registryType": "pypi",
+                "registryBaseUrl": "https://pypi.org",
+                "identifier": "agentic-hil",
+                "version": version,
+                "runtimeHint": "uvx",
+                "transport": {"type": "stdio"},
+                "packageArguments": [{"type": "positional", "value": "mcp-stdio"}],
+            }
+        ],
+    }
+    if registry != expected_registry:
+        found.append("server.json differs from the locally validated release contract")
+
+    expected_plugin = {
+        "name": "agentic-hil",
+        "displayName": "Agentic Hardware-in-the-Loop",
+        "version": version,
+        "description": (
+            "Safe embedded firmware development with local hardware-in-the-loop targets, "
+            "exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN)."
+        ),
+        "author": {"name": "Hannes Pauli"},
+        "repository": "https://github.com/agentic-hil/agentic-hil",
+        "license": "Apache-2.0",
+        "keywords": ["embedded", "firmware", "hardware-in-the-loop", "mcp", "stm32", "openocd"],
+    }
+    if _json_document(root, "plugins/agentic-hil/.claude-plugin/plugin.json") != expected_plugin:
+        found.append("plugin.json differs from the locally validated release contract")
+
+    expected_marketplace = {
+        "name": "agentic-hil",
+        "description": "Official Claude Code plugins for Agentic Hardware-in-the-Loop.",
+        "owner": {"name": "agentic-hil"},
+        "plugins": [
+            {
+                "name": "agentic-hil",
+                "displayName": "Agentic Hardware-in-the-Loop",
+                "description": (
+                    "Safe embedded firmware development with hardware-in-the-loop targets "
+                    "via policy-gated MCP tools."
+                ),
+                "source": "./plugins/agentic-hil",
+                "version": version,
+                "license": "Apache-2.0",
+            }
+        ],
+    }
+    if _json_document(root, ".claude-plugin/marketplace.json") != expected_marketplace:
+        found.append("marketplace.json differs from the locally validated release contract")
+
+    return found
+
+
+def problems(root: Path, release_tag: str | None = None) -> list[str]:
+    return [
+        *version_problems(root, release_tag),
+        *uncovered_files(root),
+        *contract_problems(root),
+    ]
+
+
+def render_list(root: Path) -> str:
+    """The checklist, printed from the check that enforces it."""
+    version = package_version(root)
+    carried = locations(root)
+    occurrences = sum(len(location.versions) for location in carried)
+    lines = [f"Release version {version} is carried in {len(carried)} files, {occurrences} occurrences:", ""]
+    for location in carried:
+        count = len(location.versions)
+        suffix = "" if count == 1 else f"  [{count} occurrences]"
+        lines.append(f"  {location.path}{suffix}")
+        lines.append(f"      {location.carries}")
+    lines.append("")
+    lines.append("Deliberately not tracking the release:")
+    for path, reason in sorted(UNTRACKED_MENTIONS.items()):
+        lines.append(f"  {path}")
+        lines.append(f"      {reason}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(argv if argv is not None else sys.argv[1:])
+    root = REPOSITORY_ROOT
+    release_tag = None
+    listing = False
+    while arguments:
+        argument = arguments.pop(0)
+        if argument == "--list":
+            listing = True
+        elif argument == "--release-tag":
+            release_tag = arguments.pop(0) if arguments else None
+        elif argument.startswith("--release-tag="):
+            release_tag = argument.split("=", 1)[1]
+        elif argument.startswith("--"):
+            raise SystemExit(f"unknown option {argument}")
+        else:
+            root = Path(argument)
+    if listing:
+        print(render_list(root))
+        return 0
+    found = problems(root, release_tag)
+    for problem in found:
+        print(problem, file=sys.stderr)
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements hardci-hq#74 and hardci-hq#75. They are one piece of work: the gate never ran where it could prevent the mistake, and the checklist standing in for it was short of reality.

## What was wrong

`validate_release` cross-checks nine version sources and byte-compares three JSON manifests against expected contracts. It is the only thing enforcing version agreement, and it could not fire on a pull request — only `release: published` or a manual dispatch on the default branch. A mismatch therefore stayed invisible until someone published the GitHub Release: the point of no return, since a PyPI version cannot be re-uploaded. Preparing 0.7.0 meant extracting the job and running it by hand to have any assurance before merging.

The checklist that stood in for it named seven positions. The release carried a version in twelve files, 19 occurrences. The five it never named include `TROUBLESHOOTING.md`'s install pins and both install-eval matrices — and that gap had already done damage: `evals/install/matrix.example.json` and `matrix.full.json` pinned `expected_version: "0.4.0"`, and `validate_source_version` (`evals/install/runner.py:80-89`) raises before a run starts, so both matrices, including the runner CLI's own default, aborted on any tree newer than 0.4.0. Unnoticed across two releases.

## What now runs where

`tools/check_version_consistency.py` is the one enforcement point. It reads files and compares strings — no secret, no OIDC, no tag.

**Pre-merge** — new `Release metadata consistency` job in `.github/workflows/ci.yml`, on every push and every pull request, wired into `Required CI` so it actually blocks:

- every position `--list` prints (twelve files, 19 occurrences) against `pyproject.toml`
- `server.json`, `plugin.json` and `marketplace.json` byte for byte against their release contracts
- the package name, and the plugin's pinned install command
- the sweep: any file carrying the release version that no entry claims

**At release** — `validate_release` in `.github/workflows/workflow.yml` runs the same module with `--release-tag`. Its 127-line inline heredoc is gone.

**Cannot move pre-merge**, and no rearrangement changes that. Named in `docs/release-strategy.md` rather than left implicit:

| | why |
|---|---|
| release tag vs `pyproject.toml` | the tag does not exist until the release is created |
| PyPI `mcp-name` ownership marker | needs the artifact PyPI has accepted |
| MCP Registry acceptance | needs the published PyPI release to verify against |

## The `paths:` filter: rejected

Considered and not taken, for three reasons. The failure this exists to catch is a change that *forgets* one of these files, and a `paths:` filter keys on the files a pull request touched — the one case it must catch is the case it would skip. It would also be a second hand-maintained enumeration of exactly the list that already drifted, needing to stay in sync with the check's own list. And the check is a few hundred milliseconds of file reads; there is nothing worth saving. The job runs unconditionally, and `ci.yml` carries that reasoning as a comment so nobody adds one later.

## The list is derived, not repeated

`docs/release-strategy.md` step 1 no longer names files. It says: bump the version in every position `python tools/check_version_consistency.py --list` prints. The list lives in `locations()`, which *is* the check, so the documentation cannot fall behind it. `CONTRIBUTING.md`'s two-file short version is redirected the same way.

The other half is `uncovered_files()`: it walks the tree and refuses any file carrying the release version that no entry in `locations()` claims, naming the file and what to do. A thirteenth home for the version cannot appear unnoticed. A file that carries a version but must *not* track the release — `AI_AGENT_QUICKSTART.md`, whose `>=0.4.0` is a capability floor — is declared in `UNTRACKED_MENTIONS` with its reason, which is a claim a reviewer can argue with. A file merely left out of a list is not.

## Proof

`tests/test_version_consistency.py`, 36 tests. It copies the tree, breaks the version in **each of the twelve positions in turn**, and asserts the check goes red naming that file — because a check that covers eleven of twelve is the thing this replaced. Also covered: a wrong release tag with and without its `v`; an absent tag being fine (that is the point of running on a pull request); each of the three manifests drifting from its contract; the sweep catching a newly created file; a version inside a longer number not counting as a mention; and that `ci.yml` runs the check with no `paths:` key and feeds `Required CI`.

## Validation

- `ruff check src tests evals tools` — clean
- `pytest` — baseline before this change 8 failed / 730 passed / 27 skipped; after 8 failed / **766** passed / 27 skipped. Identical failure set (the `test_skill_install_*`, `test_codex_skill_update_*` and `test_initialize_carries_*` group), environmental on the machine used, unrelated to this change.
- workflows: both parse with `yaml.safe_load`, both clean under `yamllint`, job graph and `needs` inspected explicitly; the check run locally in all three modes — no tag, `--release-tag v0.7.0`, and empty `RELEASE_TAG` as `workflow_dispatch` passes it. A deliberate `0.6.9` in `matrix.full.json` was refused. The `pull_request` trigger itself is only exercised by this PR's own run.

## Release classification

Repository infrastructure. It ships nothing to users: no source file, no packaged skill, no manifest, no documented behaviour of the installed tool changes. Under decision 0019 it is neither patch nor minor, and needs no release. `CHANGELOG.md` is deliberately untouched.

