### PR TITLE
Recognise @vX.Y.Z tag pins in the version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The entries below add surface — configuration keys, MCP tools, a resource, a c
 
 ### Development
 
+- The version gate now sees `agentic-hil@vX.Y.Z` git-tag pins: TROUBLESHOOTING.md's pin is a tracked location of its own, and a project-tied `@v` pin in any covered file that no entry claims fails the gate — the mention shape that drifted by hand through four releases while the file counted as covered (hardci-hq#86). Third-party pins such as `actions/checkout@v4` stay invisible: only a pin whose reference names this project states this project's version.
 - `tools/ci_linux.py` runs the committed tree in a Linux container, so a Windows machine can see the POSIX half of the suite before CI does. Three changes in two days were green on Windows and failed on all four POSIX runners; each was obvious in ninety seconds here. It clones out of a read-only mount rather than working in it, because a bind mount would carry `.venv` in and present NTFS permissions to exactly the mode tests this exists to run.
 
 ### Removed

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -19,6 +19,7 @@ from check_version_consistency import (  # noqa: E402
     package_version,
     problems,
     render_list,
+    unclaimed_pins,
     uncovered_files,
     version_problems,
 )
@@ -79,12 +80,20 @@ def test_every_stated_position_actually_carries_a_version() -> None:
 
 
 def test_the_troubleshooting_pins_are_all_of_them() -> None:
-    """Five `agentic-hil>=` pins, not the one somebody happened to remember."""
-    pins = next(
-        location for location in locations(REPOSITORY_ROOT) if location.path == "TROUBLESHOOTING.md"
-    ).versions
+    """Five `agentic-hil>=` pins and one `@vX.Y.Z` git-tag pin.
 
-    assert len(pins) == 5, pins
+    Two entries for one file, because they are two claims: the requirement
+    pins the fix instructions hand a reader, and the git-tag pin hardci-hq#86
+    found drifting by hand while `_requirement_pins` could not see it.
+    """
+    entries = [location for location in locations(REPOSITORY_ROOT) if location.path == "TROUBLESHOOTING.md"]
+
+    assert len(entries) == 2, entries
+    requirement_pins, tag_pins = entries
+    assert ">=" in requirement_pins.carries
+    assert len(requirement_pins.versions) == 5, requirement_pins
+    assert "git-tag pin" in tag_pins.carries
+    assert len(tag_pins.versions) == 1, tag_pins
 
 
 def test_the_checklist_points_at_the_check_instead_of_repeating_it() -> None:
@@ -130,6 +139,7 @@ def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
     assert version_problems(tree) == []
     assert contract_problems(tree) == []
     assert uncovered_files(tree) == []
+    assert unclaimed_pins(tree) == []
 
 
 @pytest.mark.parametrize(
@@ -182,6 +192,13 @@ def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
             "TROUBLESHOOTING.md",
             lambda text, version: text.replace(f"agentic-hil>={version}", "agentic-hil>=9.9.9", 1),
             "TROUBLESHOOTING.md",
+        ),
+        # The pin hardci-hq#86 found: a git tag in an install URL, which is not
+        # a requirement pin and went unchecked while the file counted as covered.
+        (
+            "TROUBLESHOOTING.md",
+            lambda text, version: text.replace(f"agentic-hil@v{version}", "agentic-hil@v0.6.0", 1),
+            "TROUBLESHOOTING.md states 0.6.0",
         ),
         (
             "evals/install/matrix.example.json",
@@ -259,6 +276,74 @@ def test_a_deliberate_mention_is_declared_rather_than_forgotten(tree: Path) -> N
 
     assert uncovered_files(tree) == []
     assert "AI_AGENT_QUICKSTART.md" in UNTRACKED_MENTIONS
+
+
+def test_a_current_tag_pin_is_recognised_and_passes(tree: Path) -> None:
+    """The other half of the hardci-hq#86 test: a correct pin is not noise."""
+    version = package_version(tree)
+    path = tree / "TROUBLESHOOTING.md"
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + f'\nuv tool install "git+https://github.com/agentic-hil/agentic-hil@v{version}"\n',
+        encoding="utf-8",
+    )
+
+    assert problems(tree) == []
+
+
+def test_a_tag_pin_in_a_covered_file_whose_entry_does_not_claim_it_fails(tree: Path) -> None:
+    """The class, not the instance, of hardci-hq#86.
+
+    evals/install/README.md is covered, but its entry extracts expected_version
+    fields — a git-tag pin there would again be a mention nothing checks, and
+    `uncovered_files` would again stay silent because the file is covered.
+    """
+    readme = tree / "evals" / "install" / "README.md"
+    readme.write_text(
+        readme.read_text(encoding="utf-8")
+        + "\nuvx --from git+https://github.com/agentic-hil/agentic-hil@v0.6.0 agentic-hil --version\n",
+        encoding="utf-8",
+    )
+
+    found = unclaimed_pins(tree)
+
+    assert found
+    assert "evals/install/README.md" in found[0]
+    assert "@v0.6.0" in found[0]
+    assert CHECK in found[0]
+    assert any("@v0.6.0" in problem for problem in problems(tree))
+
+
+def test_a_tag_pin_in_an_untracked_file_is_reported(tree: Path) -> None:
+    """The sweep's version regex must see through the `@v` spelling."""
+    version = package_version(tree)
+    (tree / "docs").mkdir(parents=True, exist_ok=True)
+    (tree / "docs" / "outage.md").write_text(
+        f"uvx --from git+https://github.com/agentic-hil/agentic-hil@v{version} agentic-hil --version\n",
+        encoding="utf-8",
+    )
+
+    found = uncovered_files(tree)
+
+    assert found
+    assert "docs/outage.md" in found[0]
+
+
+def test_a_third_party_action_pin_is_not_this_projects_version(tree: Path) -> None:
+    """`actions/setup-python@v5.1.0` is somebody else's version.
+
+    The reference before the `@` must name this project, or the pin says
+    nothing about this release: a stale third-party pin in a covered file must
+    not fail the gate, and `@v4` is not even a release-version shape.
+    """
+    path = tree / "TROUBLESHOOTING.md"
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + "\n- uses: actions/checkout@v4\n- uses: actions/setup-python@v5.1.0\n",
+        encoding="utf-8",
+    )
+
+    assert problems(tree) == []
 
 
 def test_a_version_inside_a_longer_number_is_not_a_mention(tree: Path) -> None:
@@ -350,7 +435,8 @@ def test_the_printed_list_names_every_position_and_its_count() -> None:
         assert path in listing
     counted = re.search(r"in (\d+) files, (\d+) occurrences", listing)
     assert counted is not None
-    assert int(counted.group(1)) == len(carried)
+    # Distinct files, not entries: TROUBLESHOOTING.md holds two claims.
+    assert int(counted.group(1)) == len({location.path for location in carried})
     assert int(counted.group(2)) == sum(len(location.versions) for location in carried)
 
 

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -21,7 +21,12 @@ release with `--release-tag`, the one comparison that genuinely needs a tag.
 check, and `--list` prints it, so `docs/release-strategy.md` can point here
 instead of repeating an enumeration that drifts. `uncovered_files` closes the
 other half — any file carrying the release version that no entry accounts for
-is an error, so a new home for the version cannot appear unnoticed.
+is an error, so a new home for the version cannot appear unnoticed. That sweep
+skips covered files, so a mention shape an entry's extractor cannot see is a
+mention nothing checks: the `agentic-hil@vX.Y.Z` git-tag pin in
+TROUBLESHOOTING.md drifted by hand through four releases that way
+(hardci-hq#86). Tag pins are now an entry of their own, and `unclaimed_pins`
+refuses a covered file whose project-tied `@v` pins its entries do not state.
 
 tomllib is deliberately absent: it is stdlib only from 3.11 and this project
 still supports 3.10, so importing it would make the gate itself the thing that
@@ -48,6 +53,14 @@ TOML_STRING = re.compile(r"""^(?P<key>[A-Za-z0-9_-]+)\s*=\s*["'](?P<value>[^"']*
 SKILL_METADATA_VERSION = re.compile(r"""^\s*agentic_hil_version:\s*["']([^"']+)["']\s*$""", re.MULTILINE)
 CHANGELOG_RELEASE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
 EXPECTED_VERSION_FIELD = re.compile(r"""["']expected_version["']\s*:\s*["']([^"']+)["']""")
+# An `@vX.Y.Z` pin: a git tag in an install URL, an action pin, a tag in a
+# release link. The reference the `@` pins — the token before it — decides
+# whose version the pin states: only a reference that names this project
+# (`agentic-hil` is the PyPI name, both halves of the repository path, and the
+# organisation any action of ours lives under) states this project's version.
+# `actions/checkout@v4` and every other third-party pin carries somebody
+# else's version and must stay invisible to this gate.
+TAG_PIN = re.compile(r"""([^\s"'`@]+)@v(\d+\.\d+\.\d+)(?![\w.])""")
 
 # The sweep walks the working tree, so it meets whatever else lives there.
 SKIPPED_DIRECTORIES = frozenset(
@@ -174,6 +187,19 @@ def _requirement_pins(root: Path, relative: str) -> tuple[str, ...]:
     return tuple(re.findall(r"agentic-hil(?:>=|==)(\d+\.\d+\.\d+)", text))
 
 
+def _tag_pins(root: Path, relative: str) -> tuple[str, ...]:
+    """Every `@vX.Y.Z` pin in a document whose reference names this project.
+
+    A different mention shape from a requirement pin: `>=` and `==` state a
+    version, a tag pin states a git reference that happens to be one. The
+    first release after this gate shipped proved the difference matters —
+    `_requirement_pins` counted five occurrences in TROUBLESHOOTING.md and the
+    sixth, `agentic-hil@v0.7.0` in a git URL, was invisible (hardci-hq#86).
+    """
+    text = _read(root, relative)
+    return tuple(match.group(2) for match in TAG_PIN.finditer(text) if "agentic-hil" in match.group(1))
+
+
 def _changelog_release(root: Path) -> str:
     match = CHANGELOG_RELEASE.search(_read(root, "CHANGELOG.md"))
     if match is None:
@@ -237,6 +263,13 @@ def locations(root: Path) -> list[Location]:
             "TROUBLESHOOTING.md",
             "every agentic-hil>= install pin the fix instructions hand a reader",
             _requirement_pins(root, "TROUBLESHOOTING.md"),
+        ),
+        # A second entry for the same file, because it is a different claim: a
+        # git-tag pin, not a version requirement (hardci-hq#86).
+        Location(
+            "TROUBLESHOOTING.md",
+            "the agentic-hil@vX.Y.Z git-tag pin: the documented install route while PyPI is unreachable",
+            _tag_pins(root, "TROUBLESHOOTING.md"),
         ),
         Location(
             "evals/install/matrix.example.json",
@@ -324,6 +357,38 @@ def uncovered_files(root: Path, version: str | None = None) -> list[str]:
                 f"add it to locations() in tools/check_version_consistency.py, "
                 f"or to UNTRACKED_MENTIONS with the reason it must not track the release"
             )
+    return found
+
+
+def unclaimed_pins(root: Path) -> list[str]:
+    """Project-tied `@vX.Y.Z` pins in covered files that no entry states.
+
+    `uncovered_files` deliberately skips a covered file, so a mention shape the
+    file's extractors cannot see is checked by nothing — the gap hardci-hq#86
+    found, where a file counted as covered while a pin in it drifted by hand
+    through four releases. This is the closing half: every pin of this shape in
+    a covered file must carry a version the file's own entries state, which
+    `version_problems` then compares against the release. A pin equal to a
+    stated version passes here and is caught there the moment it goes stale.
+
+    Two gaps stay open, named rather than closed. A file in UNTRACKED_MENTIONS
+    is excused wholesale by its declared reason. And an uncovered file is the
+    sweep's job, which recognises the current release string — so a pin born
+    already stale in a brand-new file is seen only by
+    tools/check_shipped_references.py, and only as a full repository URL in a
+    shipped document.
+    """
+    claimed: dict[str, set[str]] = {}
+    for location in locations(root):
+        claimed.setdefault(location.path, set()).update(location.versions)
+    found = []
+    for relative in sorted(claimed):
+        for pinned in _tag_pins(root, relative):
+            if pinned not in claimed[relative]:
+                found.append(
+                    f"{relative} pins this project at @v{pinned}, but no entry in locations() claims that pin: "
+                    f"extend the file's entry in tools/check_version_consistency.py so the pin is checked"
+                )
     return found
 
 
@@ -424,6 +489,7 @@ def problems(root: Path, release_tag: str | None = None) -> list[str]:
     return [
         *version_problems(root, release_tag),
         *uncovered_files(root),
+        *unclaimed_pins(root),
         *contract_problems(root),
     ]
 
@@ -433,7 +499,10 @@ def render_list(root: Path) -> str:
     version = package_version(root)
     carried = locations(root)
     occurrences = sum(len(location.versions) for location in carried)
-    lines = [f"Release version {version} is carried in {len(carried)} files, {occurrences} occurrences:", ""]
+    # Distinct paths, not entries: a file may hold several claims — TROUBLESHOOTING.md
+    # carries requirement pins and a git-tag pin as two entries.
+    files = len({location.path for location in carried})
+    lines = [f"Release version {version} is carried in {files} files, {occurrences} occurrences:", ""]
     for location in carried:
         count = len(location.versions)
         suffix = "" if count == 1 else f"  [{count} occurrences]"


### PR DESCRIPTION
Implements an internal item. Development tooling; no shipped code changes.

## The blind spot

`tools/check_version_consistency.py` guards every place the release version appears — but only in the shapes it knew. A file the gate already tracks could carry the version as a tag pin (`agentic-hil@v0.7.1` in a git-URL install route, an action-style reference) and the gate neither checked it nor counted it as covered. The dangerous half was the silence: `locations()` doubles as checklist and coverage proof, so a mention shape the scanner cannot see is a mention that goes stale without any gate failing. Exactly that happened with `TROUBLESHOOTING.md`'s documented git-tag install route.

## What changed

- `_tag_pins()` + a `TAG_PIN` regex recognise `<reference>@vX.Y.Z` pins. A second `Location` claims the `TROUBLESHOOTING.md` pin as what it is: the documented install route while PyPI is unreachable. `--list` now prints 12 files, 20 occurrences.
- **The class is closed, not the instance:** a new `unclaimed_pins()` check makes any project-tied `@v` pin in *any* covered file fail the gate unless a `Location` claims it. A pin appearing tomorrow in a covered README fails immediately instead of going silently stale.
- **Discrimination rule** (stated in the comment): the token before the `@` decides whose version the pin states — only references containing `agentic-hil` count. `actions/checkout@v4` and every third-party pin stays invisible; proven with a semver-shaped, stale `actions/setup-python@v5.1.0` in a covered file that correctly stays silent.

## Verification

- `ruff check src tests evals tools` clean; `tools/check_version_consistency.py .` silent on this tree
- `pytest`: **966 passed / 23 skipped / 0 failed** (exactly +5 tests against this machine's master count, verified by collection diff)
- `python tools/ci_linux.py`: 961 passed / 27 skipped / 1 failed — the failure is **pre-existing on unmodified master** and container-specific: without `--init`, `bash -c` is PID 1, the SIGKILLed group leader is never reaped, and `test_process_cleanup_handles_exited_group_leader` sees the zombie as a live group member. Fixed separately.
- Five new tests: stale pin fails, current pin passes, unclaimed pin in a covered file fails, project pin in an untracked file is swept, third-party pins never flag.