### PR TITLE
Give the CI container an init so zombies get reaped

### DIFF
--- a/tools/ci_linux.py
+++ b/tools/ci_linux.py
@@ -106,7 +106,12 @@ def main(argv: list[str] | None = None) -> int:
     forwarded = [argument for argument in options.pytest_args if argument != "--"]
     script = SCRIPT.format(args=" ".join(forwarded) if forwarded else "-q")
 
-    command = ["docker", "run", "--rm", "-v", f"{docker_mount_source(root)}:/src:ro", image, "bash", "-c", script]
+    # --init, or `bash -c` is PID 1 and reaps nothing: a SIGKILLed process-group
+    # leader then lingers as a zombie that still counts as a live group member,
+    # and test_process_cleanup_handles_exited_group_leader fails in the container
+    # while passing everywhere an init exists. The CI runners have one; give the
+    # container one too so this runs what CI runs.
+    command = ["docker", "run", "--rm", "--init", "-v", f"{docker_mount_source(root)}:/src:ro", image, "bash", "-c", script]
     print(f"{image}: the committed tree at {root}", flush=True)
     return subprocess.run(command, check=False).returncode
 


### PR DESCRIPTION
One line plus its comment. Found while verifying the version-gate change (#98), reproduced on unmodified master in a dedicated container run before blaming anything else.

Without `--init`, `bash -c` is PID 1 inside the container and reaps no orphaned children. A SIGKILLed process-group leader lingers as a zombie that still counts as a live group member, so `test_process_cleanup_handles_exited_group_leader` failed deterministically in the `tools/ci_linux.py` container — and nowhere else, because every host and every CI runner has a real init. Now the container does too, so the tool runs what CI runs.

Proof, after committing: `python tools/ci_linux.py tests/test_agentic_hil.py -q -k test_process_cleanup` → 2 passed. Before: `RuntimeError: Process group remained active after SIGKILL` from `src/agentic_hil/process.py:165`.

No CHANGELOG entry: the tool landed in the current unreleased cycle, so there is no released behaviour to correct.