### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Safe embedded firmware development with hardware-in-the-loop targets via policy-gated MCP tools.",
       "source": "./plugins/agentic-hil",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-09
+
 ### Added
 
 - `com_ports.<name>.vid` and `com_ports.<name>.pid`, beside `serial_number` and optional like it, and the open-time identity check compares them when they are set (#130). A USB serial number is unique within its vendor and nowhere else, so the check that shipped in 0.9.0 accepted the same serial from a completely different kind of adapter; a matching serial under a foreign vid/pid is now `com_port_identity_mismatch` as well, with `expected_vid`/`expected_pid` and `found_vid`/`found_pid` beside the serials and the hexadecimal pair in the summary. An entry that names the ids and no serial — the cheap CH340 clones publish none — gets a named type check instead of nothing: `identity_source` reads `vid_pid`, and both the confirmation and `doctor` say out loud that it separates one kind of adapter from another and not one adapter from an identical one. `adopt-hardware` and `init` write the ids from the same discovery record that already carried them, reported exactly like the serial. Both spellings load: a number is the decimal pyserial reports (`1155`), a quoted value is the hexadecimal `lsusb` prints (`"0483"`, `"0x0483"`), and both normalise to the integer. A configuration that names neither key is checked exactly as it was.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix — all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.9.0"
+python -m pip install --user --upgrade "agentic-hil>=0.10.0"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -31,12 +31,12 @@ agentic-hil setup --help
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.9.0" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.9.0 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.9.0"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.10.0" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.10.0 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.10.0"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.9.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.9.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.10.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.10.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Two Linux failures leave no installation behind and are not a broken machine. `error: externally-managed-environment` is PEP 668: Debian and Ubuntu mark the system Python as owned by the distribution and `pip` refuses it, `--user` included, so the pip block above does not apply on those hosts — `uv` and `pipx` install into environments of their own and need no exception. `invalid peer certificate: UnknownIssuer` from `uv`, or `self-signed certificate in certificate chain`, is a TLS-intercepting proxy: `uv` validates against roots bundled in its binary, while `curl` and `apt` on the same host read the system trust store and keep working, which is what makes the difference recognisable. `uv tool install --system-certs` (older releases: `--native-tls`) points `uv` at that same store. Prefer `UV_SYSTEM_CERTS=1` in the operator's environment over the flag on a single command line: `agentic-hil upgrade` shells out to `uv tool upgrade` and passes no TLS flags of its own, so a proxied host that fixed only the install command loses the upgrade path. If `--system-certs` does not help, the proxy's CA is missing from the system trust store itself; installing it there is the fix, and `--allow-insecure-host` or any other switch that disables verification is not a fallback.
 

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -328,7 +328,7 @@ For release evaluation, use `target.mode: "remote"` with immutable values:
 ```json
 {
   "mode": "remote",
-  "expected_version": "0.9.0",
+  "expected_version": "0.10.0",
   "install_spec": "git+https://github.com/agentic-hil/agentic-hil@0123456789abcdef0123456789abcdef01234567",
   "expected_commit": "0123456789abcdef0123456789abcdef01234567"
 }

--- a/evals/install/matrix.example.json
+++ b/evals/install/matrix.example.json
@@ -12,7 +12,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.9.0"
+    "expected_version": "0.10.0"
   },
   "jobs": [
     {

--- a/evals/install/matrix.full.json
+++ b/evals/install/matrix.full.json
@@ -17,7 +17,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.9.0"
+    "expected_version": "0.10.0"
   },
   "jobs": [
     {

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Safe embedded firmware development with local hardware-in-the-loop targets, exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN).",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.9.0"
+  agentic_hil_version: "0.10.0"
 ---
 
 # Agentic HIL
@@ -358,11 +358,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.9.0"
+uv tool install --upgrade "agentic-hil==0.10.0"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.9.0`. If `uv` is unavailable or a
+The version check must report exactly `0.10.0`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. `invalid peer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.9.0"
+version = "0.10.0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use for any embedded firmware or hardware request in this project — flashing, resetting, probing, debugging, reading UART or CAN traffic, collecting firmware artifacts or test reports — and for configuring Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.9.0"
+  agentic_hil_version: "0.10.0"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
Cut 0.10.0: every position `tools/check_version_consistency.py --list` prints moves from 0.9.0 to 0.10.0, and the unreleased changelog becomes the 0.10.0 section dated 2026-08-09.

What ships, in one breath: the test reactor gets a device base-class hierarchy with CAN steps; serial identity compares vid/pid beside the serial number; quarantine presupposes contact (exclusive opens, contact marker); a failed run aborts into an automatic recovery action and a successful recovery resolves its own incident; the server can upgrade itself over MCP behind `permissions.allow_upgrade`; a dead owner that never reached the bench is released. Details in the 0.10.0 changelog section.

Verification: `check_version_consistency.py` silent; ruff clean; full Windows suite 1476 passed / 35 skipped; `python -m build` + `twine check` PASSED on both artifacts.