### PR TITLE
fix(coordination): refuse a run declaration mixing devices and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **A run declaration mixing device objects with hand-written resource names is refused instead of half locked.** `bench_run_start` accepts either form, and the acquisition chose its branch on whether any device object was present: one device sent the whole declaration down the device branch, so every bare name beside it was never taken — while the declared set covered both, and the run reported the named board as held for its whole length. A foreign holder could take that board while the run counted it as its own, which is invisible from inside the run and is the outcome the device path was built to prevent. The mixed form is now refused with `invalid_argument` before anything is locked, naming both halves of the declaration (`device_lock_keys`, `declared_resource_names`) so the caller can see which one it wrote. Neither homogeneous form changes: a declaration of devices is resolved, collapsed and taken exactly as before, and one of bare names is locked exactly as before. No caller passes the mixed form — every one of them hands over a device set or a list of names — so this closes a boundary rather than removing a capability. (#140)
+
 ## [0.10.0] - 2026-08-09
 
 ### Added

--- a/src/agentic_hil/coordination.py
+++ b/src/agentic_hil/coordination.py
@@ -391,9 +391,10 @@ class HardwareCoordinator:
         of a run met no lock at all. The run holds its devices from here until
         end_run, and every call inside it borrows that hold.
 
-        Accepts Device objects or already-derived resource names. Devices are the
-        intended form — they carry the hardware identity and collapse two config
-        entries naming one unit onto one lock before anything is taken."""
+        Accepts Device objects or already-derived resource names, one form or the
+        other. Devices are the intended form — they carry the hardware identity and
+        collapse two config entries naming one unit onto one lock before anything
+        is taken. A declaration mixing the two is refused; see below for why."""
         with self._guard:
             self._require_open()
             if self.run_active:
@@ -406,7 +407,31 @@ class HardwareCoordinator:
                 # results nobody could stand behind afterwards.
                 raise CoordinationError(self._quarantined_result(sorted(self.incident_resources), "This bench has an unresolved incident; recover it before declaring a run."))
             given = resources.devices if isinstance(resources, DeviceSet) else tuple(resources)
-            device_set = resources if isinstance(resources, DeviceSet) else DeviceSet.of([item for item in given if isinstance(item, Device)])
+            objects = [item for item in given if isinstance(item, Device)]
+            names = [item for item in given if isinstance(item, str)]
+            if objects and names:
+                # One form or the other, because only one of them is ever locked.
+                # The acquisition below picks its branch on whether any device is
+                # present, so a single Device sends the whole declaration down the
+                # device branch and the hand-written names are never taken — while
+                # `declared` covers both and reports them as held. A declared board
+                # that is reported as held and never locked is the one outcome
+                # worse than refusing the run, and it is invisible from here: a
+                # foreign BenchMutex takes the named board while this run counts it
+                # as its own. No caller needs the mixed form — resolve the names to
+                # devices, or declare the whole run as names.
+                raise CoordinationError(
+                    {
+                        "ok": False,
+                        "error_type": "invalid_argument",
+                        "summary": "A run declares devices or already-derived resource names, not both: only the device half of a mixed declaration would be locked, and the named half would be reported as held without ever being taken.",
+                        "device_lock_keys": sorted(set(lock_keys(objects))),
+                        "declared_resource_names": sorted(set(names)),
+                        "retry_safe": False,
+                        "side_effect_committed": False,
+                    }
+                )
+            device_set = resources if isinstance(resources, DeviceSet) else DeviceSet.of(objects)
             declared = physical_resources(lock_keys(given))
             # Before the empty check, so a device that resolved to an unlockable
             # key is named as such instead of read as "you declared nothing".
@@ -423,7 +448,10 @@ class HardwareCoordinator:
                 # two by the time this raises. A declaration made of devices goes
                 # through DeviceSet, which additionally refuses a key the mutex
                 # would not lock — silently not locking a declared board is the
-                # one outcome worse than refusing the run.
+                # one outcome worse than refusing the run. The branch is total
+                # because the mixed form was refused above: a declaration is
+                # either all devices, in which case the set is every one of them,
+                # or all names, in which case there is no set to take.
                 if device_set:
                     device_set.acquire(self.bench, wait_s=wait_s)
                 else:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -691,6 +691,72 @@ def test_a_run_declared_with_bare_resource_names_still_works(tmp_path: Path) -> 
         coordinator.close()
 
 
+def test_a_declaration_mixing_devices_and_names_is_refused(tmp_path: Path) -> None:
+    """Half a declaration locked and all of it reported as held is worse than no run.
+
+    The acquisition picks its branch on whether any Device is present, so one
+    Device sends the whole declaration down the device branch and every
+    hand-written name beside it is never taken — while the declared set covers
+    both and every later answer names them as held. A foreign BenchMutex could
+    then take the named board out from under a run counting it as its own, which
+    is invisible from inside the run. No caller needs the mixed form, so it is
+    refused before anything is locked."""
+    config = four_device_config(tmp_path)
+    device = uart_device(config, "port_a")
+    coordinator = HardwareCoordinator(config, "owner")
+    try:
+        with pytest.raises(CoordinationError) as excinfo:
+            coordinator.begin_run([device, "physical:board-b"], label="mixed")
+
+        result = excinfo.value.result
+        assert result["error_type"] == "invalid_argument"
+        # Both halves are named, so the refusal says which declaration was made
+        # instead of leaving the caller to work out which item was the problem.
+        assert result["device_lock_keys"] == ["physical:board-a"]
+        assert result["declared_resource_names"] == ["physical:board-b"]
+        assert result["retry_safe"] is False
+        assert result["side_effect_committed"] is False
+        # Refused before the acquisition: no run is open, and the device half is
+        # not left locked by a run that never began.
+        assert coordinator.run_active is False
+        assert coordinator.bench.held_resources() == frozenset()
+        # Neither board is claimed, which is the honest state — the failure being
+        # refused here is a board that is reported as held and never locked.
+        stranger = BenchMutex(frontend="stranger")
+        try:
+            assert stranger.acquire(["physical:board-a", "physical:board-b"]) == ["physical:board-a", "physical:board-b"]
+        finally:
+            stranger.release_all()
+    finally:
+        coordinator.close()
+
+
+def test_both_homogeneous_declarations_still_take_every_key_they_declare(tmp_path: Path) -> None:
+    """Refusing the mixed form costs neither of the two forms callers use.
+
+    Devices are what the MCP path and the reactor hand over, and bare names are
+    what the older suite declares; each must still lock everything it names, or
+    the refusal would have bought a narrower boundary by breaking a working one."""
+    config = four_device_config(tmp_path)
+    coordinator = HardwareCoordinator(config, "owner")
+    try:
+        started = coordinator.begin_run([uart_device(config, "port_a"), uart_device(config, "port_b")], label="devices-only")
+
+        assert started["declared_devices"] == ["physical:board-a", "physical:board-b"]
+        assert [entry["id"] for entry in started["devices"]] == ["port_a", "port_b"]
+        assert coordinator.bench.held_resources() == frozenset({"physical:board-a", "physical:board-b"})
+        coordinator.end_run()
+
+        started = coordinator.begin_run(["physical:board-c", "physical:board-d"], label="names-only")
+
+        assert started["declared_devices"] == ["physical:board-c", "physical:board-d"]
+        assert "devices" not in started
+        assert coordinator.bench.held_resources() == frozenset({"physical:board-c", "physical:board-d"})
+    finally:
+        coordinator.end_run()
+        coordinator.close()
+
+
 def test_a_run_is_refused_before_it_holds_anything_when_a_device_is_unknown(tmp_path: Path) -> None:
     """Resolution finishes before acquisition starts."""
     config = four_device_config(tmp_path)


### PR DESCRIPTION
Fixes #140.

`begin_run` partitions the declaration and refuses `invalid_argument` when Device objects and bare strings are mixed — before any acquisition, so neither half is left locked. The payload names both halves; homogeneous declarations are pinned unchanged. Suite 1478 passed / 35 skipped; teeth by targeted revert.

Noted while there, not covered here: `lock_keys` still silently drops declaration items that are neither Device nor str — separate issue to follow.