### PR TITLE
fix(process): spawning a contained child is one call, not two halves

### DIFF
--- a/src/agentic_hil/backends/common.py
+++ b/src/agentic_hil/backends/common.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from agentic_hil.process import (
     CHILD_REAP_TIMEOUT_S,
-    process_group_kwargs,
     spawn_managed_process,
     terminate_process_tree,
 )
@@ -97,7 +96,6 @@ def spawn_command(command: list[str], cwd: str, timeout_seconds: float) -> Compl
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            **process_group_kwargs(),
         )
     except FileNotFoundError:
         return CompletedCommand(stdout="", stderr="", returncode=None, timed_out=False, not_found=True)

--- a/src/agentic_hil/backends/gdbdebug.py
+++ b/src/agentic_hil/backends/gdbdebug.py
@@ -18,7 +18,7 @@ from agentic_hil.gdbmi import (
     write_intel_hex_file,
 )
 from agentic_hil.knowledge import exclusive_permission_summary
-from agentic_hil.process import process_group_kwargs, spawn_managed_process, terminate_process_tree
+from agentic_hil.process import spawn_managed_process, terminate_process_tree
 from agentic_hil.report import (
     logs_directory,
     mark_audit_failure,
@@ -149,7 +149,6 @@ class GdbDebugSessions:
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                **process_group_kwargs(),
             )
         except OSError as error:
             # The spawn itself raised: no server process ever existed, so

--- a/src/agentic_hil/can.py
+++ b/src/agentic_hil/can.py
@@ -33,7 +33,6 @@ from agentic_hil.process import (
     cleanup_registered_processes,
     current_process_owner,
     managed_process_owner,
-    process_group_kwargs,
     spawn_managed_process,
 )
 from agentic_hil.provisional import (
@@ -1078,7 +1077,7 @@ def open_process_adapter(config: AgenticHILConfig, bus_id: str, bus_config: CanB
         return {"ok": False, "tool": "can_session_start", "bus_id": bus_id, "adapter": "process", "error_type": "can_adapter_not_found", "summary": "CAN adapter bridge executable could not be found.", "side_effect_committed": False}
     command = invocation(executable)
     try:
-        child = spawn_managed_process(command, cwd=str(Path(executable).parent), text=True, encoding="utf-8", errors="replace", stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **process_group_kwargs())
+        child = spawn_managed_process(command, cwd=str(Path(executable).parent), text=True, encoding="utf-8", errors="replace", stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError as error:
         return {"ok": False, "tool": "can_session_start", "bus_id": bus_id, "adapter": "process", "error_type": "can_adapter_process_start_failed", "summary": "CAN adapter bridge process could not be started.", "backend_error": str(error), "side_effect_committed": False}
     session = ProcessCanAdapterSession(child, bus_config.timeout_s)

--- a/src/agentic_hil/canbroker.py
+++ b/src/agentic_hil/canbroker.py
@@ -83,6 +83,7 @@ from agentic_hil.config import (
     safe_read_text,
 )
 from agentic_hil.devices import DeviceError, can_device
+from agentic_hil.process import spawn_detached_process
 from agentic_hil.report import logs_directory, safe_filename, timestamp_for_filename
 from agentic_hil.types import AgenticHILConfig, CanBusConfig, CanShareConfig, JsonObject
 
@@ -1163,30 +1164,17 @@ def _attach_once(config: AgenticHILConfig, bus_id: str, participant: str, bus_ke
     return Participant(config, bus_id, participant, connection, answer, owner, lock_key, broker_process=started)
 
 
-def _detached_spawn_kwargs() -> dict[str, object]:
-    """Process-creation flags for a child that outlives the run that started it.
-
-    Deliberately *not* :func:`agentic_hil.process.process_group_kwargs`, and the
-    difference is the whole point of this function existing. That helper is half
-    of a two-part contract: on Windows it adds ``CREATE_SUSPENDED``, and the
-    child stays frozen until :func:`~agentic_hil.process.register_process_group`
-    resumes it — which also puts it in a kill-on-close Job Object owned by the
-    spawning process. Both halves are wrong here. A broker that dies with the
-    handle of whichever run happened to attach first is not a shared bus; the
-    second participant would lose the medium because the first one's run ended.
-
-    So the broker gets process-group isolation without the containment: its own
-    group so a Ctrl-C in the first run's console does not take the bus out from
-    under the others, and no console of its own, since nobody is at a terminal
-    for it. Its lifetime is bounded by its own rules instead — the last
-    participant detaching, and the first-attach deadline below."""
-    if os.name == "nt":
-        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS}
-    return {"start_new_session": True}
-
-
 def _spawn_broker(config: AgenticHILConfig, bus_id: str, bus_key: str, lock_root: Path) -> subprocess.Popen:
     """Start a broker for this bus, detached from the run that started it.
+
+    :func:`~agentic_hil.process.spawn_detached_process` rather than
+    ``spawn_managed_process``, and the difference is the whole reason the broker
+    is spawned through the detached name: a managed child joins a kill-on-close
+    Job Object owned by this run, and a broker that died with whichever run
+    happened to attach first would not be a shared bus — the second participant
+    would lose the medium because the first one's run ended. The broker's
+    lifetime is bounded by its own rules instead: the last participant
+    detaching, and the first-attach deadline below.
 
     Losing the race for the bus lock is a clean exit, not an error — the
     winner's descriptor is what the loser's client then finds.
@@ -1199,7 +1187,7 @@ def _spawn_broker(config: AgenticHILConfig, bus_id: str, bus_key: str, lock_root
     # reading a broker's stderr once the run that started it has moved on, and a
     # full pipe would block the broker mid-bus.
     with open(broker_log_path(bus_key, lock_root), "ab") as handle:
-        return subprocess.Popen(
+        return spawn_detached_process(
             [
                 sys.executable,
                 "-m",
@@ -1215,7 +1203,6 @@ def _spawn_broker(config: AgenticHILConfig, bus_id: str, bus_key: str, lock_root
             stdout=handle,
             stderr=handle,
             cwd=str(config.work_dir),
-            **_detached_spawn_kwargs(),
         )
 
 

--- a/src/agentic_hil/gdbmi.py
+++ b/src/agentic_hil/gdbmi.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agentic_hil.config import atomic_write_text
-from agentic_hil.process import process_group_kwargs, spawn_managed_process, terminate_process_tree
+from agentic_hil.process import spawn_managed_process, terminate_process_tree
 from agentic_hil.types import JsonObject
 
 GDB_MI_ARGS = ["--nx", "--quiet", "--interpreter=mi2", "--init-eval-command=set auto-load off"]
@@ -56,7 +56,6 @@ class GdbMiClient:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            **process_group_kwargs(),
         )
         self.lock = threading.Lock()
         self.next_token = 0

--- a/src/agentic_hil/process.py
+++ b/src/agentic_hil/process.py
@@ -14,6 +14,10 @@ CHILD_REAP_TIMEOUT_S = 5.0
 _PROCESS_RECORDS: dict[int, ManagedProcessRecord] = {}
 _PROCESS_RECORDS_LOCK = threading.RLock()
 _PROCESS_OWNER: ContextVar[str | None] = ContextVar("agentic_hil_process_owner", default=None)
+# Marks a child as one this module spawned suspended and therefore owes a
+# resume. Nothing outside this module can hand it out, which is what keeps the
+# registration half from being called on its own.
+_SPAWN_TOKEN = object()
 
 
 @dataclass(frozen=True)
@@ -41,11 +45,30 @@ class ManagedProcessRecord:
 
 
 def spawn_managed_process(args: Any, **kwargs: Any) -> subprocess.Popen:
-    child = subprocess.Popen(args, **kwargs)
+    """Start a contained child and hand it back running.
+
+    Spawning, containment and resumption are one call because they were once
+    three, and two of them were optional-looking. On Windows the child is born
+    suspended so that no instruction of it executes before it is inside a
+    kill-on-close Job Object — which is the only way a descendant that outlives
+    its parent still dies with this run. A caller that took the creation flags
+    and skipped the containment got a child frozen forever: alive, silent, no
+    output to read and no exit code to classify. That is not a mistake a
+    docstring prevents, so the two halves are private below and this function
+    is the only thing that calls them, in the only order that works.
+
+    Process-group and detachment flags are the contract, not a parameter: pass
+    them and this refuses rather than letting a caller re-open the hole from
+    the outside. For a child that must outlive this run's containment, use
+    :func:`spawn_detached_process`, which says so in its name.
+    """
+    _reject_creation_kwargs("spawn_managed_process", kwargs)
+    child = subprocess.Popen(args, **kwargs, **_process_group_kwargs())
+    child._agentic_hil_spawn_token = _SPAWN_TOKEN
     with _PROCESS_RECORDS_LOCK:
         _PROCESS_RECORDS[id(child)] = ManagedProcessRecord(child, owner_marker=_PROCESS_OWNER.get())
     try:
-        return register_process_group(child)
+        return _register_process_group(child)
     except BaseException as primary_error:
         if os.name == "nt":
             raise
@@ -54,6 +77,45 @@ def spawn_managed_process(args: Any, **kwargs: Any) -> subprocess.Popen:
         except BaseException as cleanup_error:
             primary_error.args = (*primary_error.args, f"Process registration cleanup error: {cleanup_error}")
         raise
+
+
+def spawn_detached_process(args: Any, **kwargs: Any) -> subprocess.Popen:
+    """Start a child that must outlive the run that started it.
+
+    The opposite trade from :func:`spawn_managed_process`, and the difference is
+    the whole reason this exists as its own name rather than as a flag. This
+    child gets process-group isolation *without* the containment: its own group,
+    so a Ctrl-C in the starting run's console does not take it out, and on
+    Windows no console of its own, since nobody is at a terminal for it. It is
+    not born suspended, it joins no Job Object, and it is not in this run's
+    managed records — so no cleanup sweep reaps it when the run that happened to
+    start it ends.
+
+    That is what a shared broker needs: one that died with the handle of
+    whichever run attached first would not be a shared bus, because the second
+    participant would lose the medium when the first one's run ended. A child
+    spawned here is bounded by its own rules instead, and owning those rules is
+    the caller's job — nothing in this module will end it.
+    """
+    _reject_creation_kwargs("spawn_detached_process", kwargs)
+    return subprocess.Popen(args, **kwargs, **_detached_process_kwargs())
+
+
+def _reject_creation_kwargs(function_name: str, kwargs: dict[str, Any]) -> None:
+    """Refuse the creation flags that are this module's to decide.
+
+    A caller passing these is trying to hold half the contract again, whether or
+    not they know it: on Windows a hand-built ``creationflags`` either drops the
+    suspended start that makes containment safe, or keeps it and leaves the
+    child frozen. Both are the bug this surface exists to remove, so they raise
+    here instead of merging into something plausible.
+    """
+    named = [key for key in ("creationflags", "start_new_session") if key in kwargs]
+    if named:
+        raise TypeError(
+            f"{function_name}() sets {' and '.join(named)} itself; passing it would break the spawn contract. "
+            "Use spawn_managed_process() for a child contained by this run, or spawn_detached_process() for one that outlives it."
+        )
 
 
 def current_process_owner() -> str | None:
@@ -69,13 +131,41 @@ def managed_process_owner(owner_marker: str):
         _PROCESS_OWNER.reset(reset_token)
 
 
-def process_group_kwargs() -> dict[str, object]:
+def _process_group_kwargs() -> dict[str, object]:
+    """Creation flags for a contained child: own group, and born suspended on Windows.
+
+    Private, and callable in practice only by :func:`spawn_managed_process`,
+    because ``CREATE_SUSPENDED`` (0x4) is an obligation rather than an option —
+    whoever spawns with it owes the child a resume, and the resume lives in
+    :func:`_register_process_group`.
+    """
     if os.name == "nt":
         return {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | 0x00000004}
     return {"start_new_session": True}
 
 
-def register_process_group(child: subprocess.Popen) -> subprocess.Popen:
+def _detached_process_kwargs() -> dict[str, object]:
+    """Creation flags for a child that outlives its spawner: own group, no console, not suspended."""
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS}
+    return {"start_new_session": True}
+
+
+def _register_process_group(child: subprocess.Popen) -> subprocess.Popen:
+    """Contain a child spawned by this module, and on Windows resume it.
+
+    Refuses any child it was not handed by :func:`spawn_managed_process`. The
+    token is not paperwork: this function's Windows path assumes the child is
+    suspended and unblocks it, so calling it on a child spawned elsewhere either
+    resumes a thread that was already running or leaves a frozen one frozen with
+    the caller believing it was handled.
+    """
+    if getattr(child, "_agentic_hil_spawn_token", None) is not _SPAWN_TOKEN:
+        raise RuntimeError(
+            "Process group registration is not a standalone step: it resumes a child that spawn_managed_process() "
+            "started suspended. Call spawn_managed_process() instead, or spawn_detached_process() for a child that "
+            "must outlive this run."
+        )
     with _PROCESS_RECORDS_LOCK:
         record = _PROCESS_RECORDS.setdefault(id(child), ManagedProcessRecord(child, owner_marker=_PROCESS_OWNER.get()))
     if os.name == "nt":

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import sys
 import time
+from contextlib import suppress
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 
@@ -3724,6 +3725,107 @@ def test_windows_missing_job_handle_terminates_suspended_child(monkeypatch: pyte
 
     assert len(spawned) == 1
     assert spawned[0].poll() is not None
+
+
+SPAWNER_SOURCE = """
+import sys
+from agentic_hil.process import {function}
+child = {function}([sys.executable, "-c", "import time; time.sleep(30)"])
+print(child.pid, flush=True)
+"""
+
+
+def grandchild_pid_after_spawner_exit(function: str) -> int:
+    """Start a child through ``function`` from a process that then exits, and report its pid.
+
+    The spawner is a plain ``subprocess.Popen`` on purpose: it must belong to no
+    Job Object of this test's making, so the only containment in the picture is
+    the one ``function`` itself creates.
+    """
+    spawner = subprocess.Popen([sys.executable, "-c", SPAWNER_SOURCE.format(function=function)], stdout=subprocess.PIPE, text=True, encoding="utf-8")
+    stdout, _ = spawner.communicate(timeout=60)
+    assert spawner.returncode == 0, stdout
+    return int(stdout.strip())
+
+
+def pid_alive_after_settling(pid: int, *, awaiting: bool, timeout_s: float = 5.0) -> bool:
+    """Poll until the pid reaches ``awaiting`` or the deadline passes, then answer.
+
+    Waiting for the answer the caller is *not* asserting is the point: a child
+    that was going to die has the full window in which to do it, so "still
+    alive" is a proof rather than a race won.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        alive = pid_alive(pid)
+        if alive == awaiting or time.monotonic() >= deadline:
+            return alive
+        time.sleep(0.05)
+
+
+def kill_pid(pid: int) -> None:
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        return
+    with suppress(ProcessLookupError):
+        os.kill(pid, 9)
+
+
+def test_managed_spawn_hands_back_a_child_that_is_already_running(tmp_path: Path) -> None:
+    """The regression this surface exists for: the caller owes no second call.
+
+    On Windows the child is born suspended, so a spawn that forgot to resume it
+    would sit here until the wait timed out — alive, silent, nothing to read.
+    """
+    marker = tmp_path / "ran"
+    child = spawn_managed_process([sys.executable, "-c", "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('ran')", str(marker)])
+    assert child.wait(timeout=10) == 0
+    assert marker.read_text(encoding="utf-8") == "ran"
+    terminate_process_tree(child, 5.0)
+
+
+def test_detached_spawn_child_outlives_the_process_that_started_it() -> None:
+    """What the CAN broker needs: a bus that does not end with the first run to attach."""
+    pid = grandchild_pid_after_spawner_exit("spawn_detached_process")
+    try:
+        assert pid_alive_after_settling(pid, awaiting=False) is True
+    finally:
+        kill_pid(pid)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Job Object containment is what the detached variant opts out of")
+def test_managed_spawn_child_dies_with_the_process_that_started_it() -> None:
+    """The contrast that gives the detached variant its meaning: same shape, opposite lifetime."""
+    pid = grandchild_pid_after_spawner_exit("spawn_managed_process")
+    try:
+        assert pid_alive_after_settling(pid, awaiting=False) is False
+    finally:
+        kill_pid(pid)
+
+
+def test_the_spawn_contract_has_no_half_a_caller_can_hold() -> None:
+    """Neither half is reachable by the name it used to have."""
+    assert not hasattr(process_module, "process_group_kwargs")
+    assert not hasattr(process_module, "register_process_group")
+
+
+def test_registration_refuses_a_child_it_did_not_spawn() -> None:
+    """Reaching past the underscore does not get the old two-step back either."""
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        with pytest.raises(RuntimeError, match="not a standalone step"):
+            process_module._register_process_group(child)
+    finally:
+        child.kill()
+        child.wait(timeout=5)
+
+
+@pytest.mark.parametrize("function", ["spawn_managed_process", "spawn_detached_process"])
+@pytest.mark.parametrize(("keyword", "value"), [("creationflags", 0), ("start_new_session", True)])
+def test_spawn_refuses_caller_supplied_creation_flags(function: str, keyword: str, value: object) -> None:
+    """The flags are the contract, so a caller cannot re-open the hole from outside."""
+    with pytest.raises(TypeError, match="spawn contract"):
+        getattr(process_module, function)([sys.executable, "-c", "pass"], **{keyword: value})
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows Job Object verification regression")

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -27,6 +27,7 @@ from fixtures import fake_openocd
 from support import trusted_launcher
 
 from agentic_hil import __version__
+from agentic_hil import process as process_module
 from agentic_hil.artifacts import ArtifactManager
 from agentic_hil.backends import openocd as openocd_backend
 from agentic_hil.backends.common import command_for_log
@@ -68,7 +69,7 @@ from agentic_hil.config import (
     user_state_root,
 )
 from agentic_hil.mcp import MCP_PROTOCOL_VERSION, MCP_TOOL_NAMES, MCP_TOOLS, handle_mcp_message
-from agentic_hil.process import ProcessImage, process_group_kwargs, register_process_group, terminate_process_tree
+from agentic_hil.process import ProcessImage, spawn_managed_process, terminate_process_tree
 from agentic_hil.report import logs_directory
 from agentic_hil.tools import AgenticHILToolService, UnprovisionedToolService
 from agentic_hil.types import CURRENT_CONFIG_VERSION
@@ -3608,7 +3609,7 @@ open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
 signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(SystemExit(0)))
 time.sleep(30)
 """
-    child = register_process_group(subprocess.Popen([sys.executable, "-c", code, str(pid_file)], **process_group_kwargs()))
+    child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     try:
         for _ in range(100):
             if pid_file.exists():
@@ -3633,7 +3634,7 @@ import signal, subprocess, sys
 descendant = subprocess.Popen([sys.executable, '-c', 'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)'])
 open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
 """
-    child = register_process_group(subprocess.Popen([sys.executable, "-c", code, str(pid_file)], **process_group_kwargs()))
+    child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     try:
         child.wait(timeout=5)
         descendant_pid = int(pid_file.read_text(encoding="utf-8"))
@@ -3654,7 +3655,7 @@ import subprocess, sys
 descendant = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])
 open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
 """
-    child = register_process_group(subprocess.Popen([sys.executable, "-c", code, str(pid_file)], **process_group_kwargs()))
+    child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     child.wait(timeout=5)
     descendant_pid = int(pid_file.read_text(encoding="utf-8"))
 
@@ -3664,14 +3665,26 @@ open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows suspended-start regression")
-def test_windows_process_does_not_run_before_job_registration(tmp_path: Path) -> None:
+def test_windows_managed_spawn_holds_child_until_contained_then_runs_it(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The suspended start is still there, and it still ends in a running child.
+
+    Both halves in one call means neither is observable from outside any more,
+    so the freeze is caught where it happens: at Job Object setup the child must
+    not have run a line yet, and by the time the call returns it must have.
+    """
     marker = tmp_path / "started"
-    child = subprocess.Popen([sys.executable, "-c", "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('started')", str(marker)], **process_group_kwargs())
+    original = process_module._create_windows_kill_job
+    frozen_at_containment: list[bool] = []
+
+    def watched(process: subprocess.Popen) -> int:
+        frozen_at_containment.append(not marker.exists())
+        return original(process)
+
+    monkeypatch.setattr("agentic_hil.process._create_windows_kill_job", watched)
+    child = spawn_managed_process([sys.executable, "-c", "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('started')", str(marker)])
     try:
-        time.sleep(0.1)
-        assert not marker.exists()
-        register_process_group(child)
         child.wait(timeout=5)
+        assert frozen_at_containment == [True]
         assert marker.read_text(encoding="utf-8") == "started"
         terminate_process_tree(child, 1.0)
     finally:
@@ -3681,24 +3694,36 @@ def test_windows_process_does_not_run_before_job_registration(tmp_path: Path) ->
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows fail-closed registration regression")
 def test_windows_job_setup_failure_terminates_suspended_child(monkeypatch: pytest.MonkeyPatch) -> None:
-    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"], **process_group_kwargs())
-    monkeypatch.setattr("agentic_hil.process._create_windows_kill_job", lambda process: (_ for _ in ()).throw(OSError("job setup failed")))
+    spawned: list[subprocess.Popen] = []
+
+    def fail(process: subprocess.Popen) -> int:
+        spawned.append(process)
+        raise OSError("job setup failed")
+
+    monkeypatch.setattr("agentic_hil.process._create_windows_kill_job", fail)
 
     with pytest.raises(OSError, match="job setup failed"):
-        register_process_group(child)
+        spawn_managed_process([sys.executable, "-c", "import time; time.sleep(30)"])
 
-    assert child.poll() is not None
+    assert len(spawned) == 1
+    assert spawned[0].poll() is not None
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows missing Job Object regression")
 def test_windows_missing_job_handle_terminates_suspended_child(monkeypatch: pytest.MonkeyPatch) -> None:
-    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"], **process_group_kwargs())
-    monkeypatch.setattr("agentic_hil.process._create_windows_kill_job", lambda process: None)
+    spawned: list[subprocess.Popen] = []
+
+    def no_handle(process: subprocess.Popen) -> None:
+        spawned.append(process)
+        return None
+
+    monkeypatch.setattr("agentic_hil.process._create_windows_kill_job", no_handle)
 
     with pytest.raises(OSError, match="no containment handle"):
-        register_process_group(child)
+        spawn_managed_process([sys.executable, "-c", "import time; time.sleep(30)"])
 
-    assert child.poll() is not None
+    assert len(spawned) == 1
+    assert spawned[0].poll() is not None
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows Job Object verification regression")

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -3728,24 +3728,37 @@ def test_windows_missing_job_handle_terminates_suspended_child(monkeypatch: pyte
 
 
 SPAWNER_SOURCE = """
-import sys
+import subprocess, sys
 from agentic_hil.process import {function}
-child = {function}([sys.executable, "-c", "import time; time.sleep(30)"])
-print(child.pid, flush=True)
+child = {function}(
+    [sys.executable, "-c", "import time; time.sleep(30)"],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+open(sys.argv[1], "w", encoding="utf-8").write(str(child.pid))
 """
 
 
-def grandchild_pid_after_spawner_exit(function: str) -> int:
+def grandchild_pid_after_spawner_exit(function: str, pid_file: Path) -> int:
     """Start a child through ``function`` from a process that then exits, and report its pid.
 
     The spawner is a plain ``subprocess.Popen`` on purpose: it must belong to no
     Job Object of this test's making, so the only containment in the picture is
     the one ``function`` itself creates.
+
+    Two details are the difference between a proof and a hang. The grandchild's
+    standard streams go to ``DEVNULL``, because on POSIX a child inherits its
+    parent's fds 0-2 and would hold the write end of any pipe open for its whole
+    life — leaving this reader blocked on an EOF that only arrives once the
+    process it is asking about has died. It is the same reason
+    :func:`agentic_hil.canbroker._spawn_broker` hands the broker a log file
+    rather than a pipe. And the pid travels through a file rather than that
+    stream, so nothing here depends on a descriptor the grandchild shares.
     """
-    spawner = subprocess.Popen([sys.executable, "-c", SPAWNER_SOURCE.format(function=function)], stdout=subprocess.PIPE, text=True, encoding="utf-8")
-    stdout, _ = spawner.communicate(timeout=60)
-    assert spawner.returncode == 0, stdout
-    return int(stdout.strip())
+    spawner = subprocess.Popen([sys.executable, "-c", SPAWNER_SOURCE.format(function=function), str(pid_file)])
+    assert spawner.wait(timeout=60) == 0
+    return int(pid_file.read_text(encoding="utf-8"))
 
 
 def pid_alive_after_settling(pid: int, *, awaiting: bool, timeout_s: float = 5.0) -> bool:
@@ -3784,9 +3797,9 @@ def test_managed_spawn_hands_back_a_child_that_is_already_running(tmp_path: Path
     terminate_process_tree(child, 5.0)
 
 
-def test_detached_spawn_child_outlives_the_process_that_started_it() -> None:
+def test_detached_spawn_child_outlives_the_process_that_started_it(tmp_path: Path) -> None:
     """What the CAN broker needs: a bus that does not end with the first run to attach."""
-    pid = grandchild_pid_after_spawner_exit("spawn_detached_process")
+    pid = grandchild_pid_after_spawner_exit("spawn_detached_process", tmp_path / "detached.pid")
     try:
         assert pid_alive_after_settling(pid, awaiting=False) is True
     finally:
@@ -3794,9 +3807,9 @@ def test_detached_spawn_child_outlives_the_process_that_started_it() -> None:
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Job Object containment is what the detached variant opts out of")
-def test_managed_spawn_child_dies_with_the_process_that_started_it() -> None:
+def test_managed_spawn_child_dies_with_the_process_that_started_it(tmp_path: Path) -> None:
     """The contrast that gives the detached variant its meaning: same shape, opposite lifetime."""
-    pid = grandchild_pid_after_spawner_exit("spawn_managed_process")
+    pid = grandchild_pid_after_spawner_exit("spawn_managed_process", tmp_path / "managed.pid")
     try:
         assert pid_alive_after_settling(pid, awaiting=False) is False
     finally:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -32,7 +32,6 @@ from agentic_hil.mcp import call_tool
 from agentic_hil.process import (
     cleanup_registered_processes,
     managed_process_owner,
-    process_group_kwargs,
     spawn_managed_process,
     terminate_process_tree,
 )
@@ -172,9 +171,9 @@ def test_stale_resource_keeps_project_cleanup_required(tmp_path: Path) -> None:
 
 def test_process_cleanup_is_scoped_to_service_owner() -> None:
     with managed_process_owner("first-owner"):
-        first = spawn_managed_process([sys.executable, "-c", "import time; time.sleep(60)"], **process_group_kwargs())
+        first = spawn_managed_process([sys.executable, "-c", "import time; time.sleep(60)"])
     with managed_process_owner("second-owner"):
-        second = spawn_managed_process([sys.executable, "-c", "import time; time.sleep(60)"], **process_group_kwargs())
+        second = spawn_managed_process([sys.executable, "-c", "import time; time.sleep(60)"])
     try:
         assert cleanup_registered_processes(owner_marker="first-owner") == []
         assert first.poll() is not None


### PR DESCRIPTION
Fixes #169.

`spawn_managed_process()` sets its creation flags itself and is the only caller of the old pair; `spawn_detached_process()` stands beside it for a child that must outlive its spawner (what the CAN broker locally reinvented). Both halves are private, registration refuses a child it did not spawn, and both spawn functions refuse caller-supplied `creationflags`/`start_new_session`. Windows 1672/38, containerized Linux 1678/32 — where the container run caught and fixed an fd-inheritance defect in this branch's own test.