### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Safe embedded firmware development with hardware-in-the-loop targets via policy-gated MCP tools.",
       "source": "./plugins/agentic-hil",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-10
+
 ### Added
 
 - The test reactor's `can_read` takes a `comparator:`: an identifier filter (`id`, optionally `id_mask`) and a payload claim (`equals`, `pattern`, or `pattern` with `range` over a hex-captured value), read until met within `timeout_s` and failing with the frames the bus did carry (#168)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix — all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.10.0"
+python -m pip install --user --upgrade "agentic-hil>=0.11.0"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -31,12 +31,12 @@ agentic-hil setup --help
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.10.0" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.10.0 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.10.0"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.11.0" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.11.0 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.11.0"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.10.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.10.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.11.0" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.11.0"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Two Linux failures leave no installation behind and are not a broken machine. `error: externally-managed-environment` is PEP 668: Debian and Ubuntu mark the system Python as owned by the distribution and `pip` refuses it, `--user` included, so the pip block above does not apply on those hosts — `uv` and `pipx` install into environments of their own and need no exception. `invalid peer certificate: UnknownIssuer` from `uv`, or `self-signed certificate in certificate chain`, is a TLS-intercepting proxy: `uv` validates against roots bundled in its binary, while `curl` and `apt` on the same host read the system trust store and keep working, which is what makes the difference recognisable. `uv tool install --system-certs` (older releases: `--native-tls`) points `uv` at that same store. Prefer `UV_SYSTEM_CERTS=1` in the operator's environment over the flag on a single command line: `agentic-hil upgrade` shells out to `uv tool upgrade` and passes no TLS flags of its own, so a proxied host that fixed only the install command loses the upgrade path. If `--system-certs` does not help, the proxy's CA is missing from the system trust store itself; installing it there is the fix, and `--allow-insecure-host` or any other switch that disables verification is not a fallback.
 

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -328,7 +328,7 @@ For release evaluation, use `target.mode: "remote"` with immutable values:
 ```json
 {
   "mode": "remote",
-  "expected_version": "0.10.0",
+  "expected_version": "0.11.0",
   "install_spec": "git+https://github.com/agentic-hil/agentic-hil@0123456789abcdef0123456789abcdef01234567",
   "expected_commit": "0123456789abcdef0123456789abcdef01234567"
 }

--- a/evals/install/matrix.example.json
+++ b/evals/install/matrix.example.json
@@ -12,7 +12,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.10.0"
+    "expected_version": "0.11.0"
   },
   "jobs": [
     {

--- a/evals/install/matrix.full.json
+++ b/evals/install/matrix.full.json
@@ -17,7 +17,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.10.0"
+    "expected_version": "0.11.0"
   },
   "jobs": [
     {

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Safe embedded firmware development with local hardware-in-the-loop targets, exposed as policy-gated MCP tools (probe, flash, reset, serial, CAN).",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench — flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports — or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware — PCB layout, schematic capture, EDA, mechanical design — and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.10.0"
+  agentic_hil_version: "0.11.0"
 ---
 
 # Agentic HIL
@@ -363,11 +363,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.10.0"
+uv tool install --upgrade "agentic-hil==0.11.0"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.10.0`. If `uv` is unavailable or a
+The version check must report exactly `0.11.0`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. `invalid peer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.10.0"
+version = "0.11.0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench — flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports — or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware — PCB layout, schematic capture, EDA, mechanical design — and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.10.0"
+  agentic_hil_version: "0.11.0"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
Cut 0.11.0: every position `tools/check_version_consistency.py --list` prints moves from 0.10.0 to 0.11.0, and the unreleased changelog becomes the 0.11.0 section dated 2026-08-10.

What ships, in one breath: the CAN broker (one process owns a shared bus, named participant views via `shares:`), the test reactor's abstract step dispatch with plan format v3 (`device:` routing, `comparator:` with equals/pattern/range on serial and CAN reads, `uart_write`, universal `delay`, optional closes), the README as a human entry point with the reference depth in docs/ and the documentation live on Read the Docs, the whole-contract spawn API, config v3's identity requirement, the invalid-argument catalogue, the POSIX launcher-trust fix, and the adversarial review loop's fourteen-finding harvest with a final CLEAN verdict over the entire span.

Verification: version gate silent; ruff clean; Windows suite 1704 passed / 38 skipped; `python -m build` + `twine check` PASSED on both artifacts; containerized Linux runs green throughout the wave.