### PR TITLE
fix(stlink): confirm each reset mode on the lines its own command prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- `reset_target(mode="halt")` on the stlink backend can report success: each reset mode is confirmed on the success line its own command prints (`-halt` on `Core halted`), instead of every mode being held to the two lines only `-rst` prints — which had turned a correct halt into `reset_unconfirmed` with an unknown side effect, quarantined the bench, and left recovery's reset-into-halt unable to attest a safe state on this backend. The connect banner is deliberately not a marker; it prints before the halt is attempted. Verified against captured vendor output and green on a real board (#142)
+
 ## [0.11.0] - 2026-08-10
 
 ### Added

--- a/src/agentic_hil/backends/stlink.py
+++ b/src/agentic_hil/backends/stlink.py
@@ -60,7 +60,26 @@ BACKEND_ERROR_TO_PUBLIC_ERROR = {
 STLINK_SUCCESS_CONFIRMATION = {
     "probe_target": ["ST-LINK SN", "Device name"],
     "flash_firmware": ["Download verified successfully"],
-    "reset_target": ["MCU Reset", "reset is performed"],
+}
+# One row per reset mode, holding the argument that goes on the wire and the
+# lines STM32CubeProgrammer prints when that argument did what it says. The two
+# belong to the same command and are kept together for that reason: `-rst` and
+# `-halt` are different commands with different success lines, and a single
+# marker set for `reset_target` carried the `-rst` lines only — mode `halt` did
+# exactly what it was asked, printed neither of them, and could therefore never
+# report anything but an unconfirmed outcome (#142).
+#
+# `-halt` measured on STM32CubeProgrammer v2.23.0 against a NUCLEO-F446RE: the
+# NORMAL connect banner carries `Reset mode  : Software reset` and the run ends
+# with `Core halted`. The banner settles what this mode does — a software reset
+# and then a halt, the same operation OpenOCD's and pyOCD's `reset halt`
+# perform — but it is not a second marker: connect prints it before the halt is
+# attempted, so a run that connected and then failed to halt prints it
+# unchanged. Only `Core halted` is the operation's own success line, and it is
+# the only one of the two a failure withholds.
+STLINK_RESET_MODES: dict[str, dict[str, list[str]]] = {
+    "run": {"args": ["-rst"], "success_text": ["MCU Reset", "reset is performed"]},
+    "halt": {"args": ["-halt"], "success_text": ["Core halted"]},
 }
 STLINK_SERIAL_PATTERN = re.compile(r"^\s*ST-?LINK\s+SN\s*:\s*(\S+)\s*$", re.IGNORECASE | re.MULTILINE)
 STLINK_DEVICE_PATTERN = re.compile(r"^\s*Device\s+name\s*:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
@@ -168,8 +187,8 @@ class STLinkBackend:
             return {"ok": False, "tool": "reset_target", "error_type": "invalid_argument", "summary": "Invalid reset mode.", "allowed_values": allowed_modes}
         if mode == "init":
             return reset_init_unsupported(self.backend_name, "STM32CubeProgrammer's CLI has no equivalent")
-        mode_args = {"run": ["-rst"], "halt": ["-halt"]}
-        result = self._run_stlink("reset_target", [*self._connection_args("NORMAL"), *mode_args[mode]])
+        selected = STLINK_RESET_MODES[mode]
+        result = self._run_stlink("reset_target", [*self._connection_args("NORMAL"), *selected["args"]], selected["success_text"])
         result["mode"] = mode
         if result.get("ok"):
             result["summary"] = f"Target reset with mode '{mode}'."
@@ -247,7 +266,7 @@ class STLinkBackend:
             return dict(STLINK_NOT_FOUND)
         return {"ok": True, "executable": found, "executable_path": found}
 
-    def _run_stlink(self, tool: str, action_args: list[str]) -> JsonObject:
+    def _run_stlink(self, tool: str, action_args: list[str], success_text: list[str] | None = None) -> JsonObject:
         started_at = utc_now_iso()
         start = time.perf_counter()
         resolved = self._resolve_executable()
@@ -268,7 +287,7 @@ class STLinkBackend:
             backend_error_type = self._backend_error_from_output(output, tool)
             if backend_error_type is not None:
                 return self._finish_log_audit(self._failure_result(tool, started_at, finished_at, elapsed_ms, backend_error_type, log_path), audit_error)
-            confirmation = self._confirm_operation_success(output, tool)
+            confirmation = self._confirm_operation_success(output, STLINK_SUCCESS_CONFIRMATION.get(tool, []) if success_text is None else success_text)
             if not confirmation["confirmed"]:
                 # Confirmation is all-or-nothing here, so this branch is also
                 # reached with some of the expected lines present — a read that
@@ -331,8 +350,9 @@ class STLinkBackend:
             return backend_error_type
         return None
 
-    def _confirm_operation_success(self, output: str, tool: str) -> JsonObject:
-        expected = STLINK_SUCCESS_CONFIRMATION.get(tool, [])
+    def _confirm_operation_success(self, output: str, expected: list[str]) -> JsonObject:
+        # All-or-nothing over whichever set the caller selected: a command is
+        # confirmed by every line it prints on success, and by nothing less.
         if not expected:
             return {"confirmed": True, "matched": None, "expected": expected}
         lower = output.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ FAKE_OPENOCD_UNCONFIRMED = ROOT / "tests" / "fixtures" / "fake_openocd_unconfirm
 FAKE_OPENOCD_POST_INIT_UNCONFIRMED = ROOT / "tests" / "fixtures" / "fake_openocd_post_init_unconfirmed.py"
 FAKE_STLINK = ROOT / "tests" / "fixtures" / "fake_stlink.py"
 FAKE_STLINK_UNCONFIRMED = ROOT / "tests" / "fixtures" / "fake_stlink_unconfirmed.py"
+FAKE_STLINK_HALT_UNCONFIRMED = ROOT / "tests" / "fixtures" / "fake_stlink_halt_unconfirmed.py"
 FAKE_STLINK_PARTIAL_CONFIRMATION = ROOT / "tests" / "fixtures" / "fake_stlink_partial_confirmation.py"
 FAKE_STLINK_NO_TARGET = ROOT / "tests" / "fixtures" / "fake_stlink_no_target.py"
 FAKE_STLINK_NO_PROBE = ROOT / "tests" / "fixtures" / "fake_stlink_no_probe.py"

--- a/tests/fixtures/fake_stlink.py
+++ b/tests/fixtures/fake_stlink.py
@@ -3,6 +3,32 @@ from __future__ import annotations
 
 import sys
 
+# The connect banner STM32CubeProgrammer prints before it runs the action it was
+# given, transcribed from a v2.23.0 run against a NUCLEO-F446RE. `Reset mode  :
+# Software reset` is what makes `-halt` a reset-then-halt rather than a bare
+# halt, and it is printed by the connect, so it is here for every action that
+# connects — including the ones that then fail, which is why the backend does
+# not read it as confirmation of anything.
+CONNECT_BANNER = """      -------------------------------------------------------------------
+                       STM32CubeProgrammer v2.18.0
+      -------------------------------------------------------------------
+
+ST-LINK SN  : STLINK123
+ST-LINK FW  : V2J30M19
+Board       : NUCLEO-F446RE
+Voltage     : 3.26V
+SWD freq    : 4000 KHz
+Connect mode: Normal
+Reset mode  : Software reset
+Device ID   : 0x421
+Revision ID : Rev A
+Device name : STM32F446RE
+NVM size    : 512 KBytes
+Device type : MCU
+Device CPU  : Cortex-M4
+BL Version  : 0x90
+"""
+
 
 def main() -> int:
     args = sys.argv[1:]
@@ -24,6 +50,12 @@ def main() -> int:
     elif "-rst" in args:
         print("MCU Reset")
         print("reset is performed")
+    elif "-halt" in args:
+        # A different command from `-rst` with a success line of its own: the
+        # CLI resets the part through the NORMAL connect and then reports the
+        # core it stopped. Neither `-rst` line appears.
+        print(CONNECT_BANNER)
+        print("Core halted")
     else:
         print("ST-LINK SN  : STLINK123")
         print("Device name : STM32F446RE")

--- a/tests/fixtures/fake_stlink_halt_unconfirmed.py
+++ b/tests/fixtures/fake_stlink_halt_unconfirmed.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""An STM32_Programmer_CLI whose `-halt` connects and never reports the halt.
+
+The failure shape of the mode `halt` confirmation, and the reason the connect
+banner is not part of it. The banner is printed in full here — `Reset mode  :
+Software reset` included — because connect happens before the halt is
+attempted, so a run that connected and then failed to stop the core prints
+exactly this. Everything the banner asserts is true and the outcome is still
+unstated, which is what the backend has to answer `reset_unconfirmed` to: the
+core may be halted, may be running, and nothing on the host knows which.
+
+Exits 0 with no failure text on purpose. A CLI that says `Error:` is classified
+from its own words and is a different result; this is the case where there are
+no words at all — a wrapper that swallowed the last line, or a version that
+words it differently.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if "--version" in args:
+        print("STM32CubeProgrammer version: 2.18.0")
+        return 0
+    print(" ".join(args))
+    print("ST-LINK SN  : STLINK123")
+    print("Board       : NUCLEO-F446RE")
+    print("Connect mode: Normal")
+    print("Reset mode  : Software reset")
+    print("Device name : STM32F446RE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -20,6 +20,7 @@ from conftest import (
     FAKE_OPENOCD,
     FAKE_OPENOCD_NO_TARGET,
     FAKE_STLINK,
+    FAKE_STLINK_HALT_UNCONFIRMED,
     FAKE_STLINK_UNCONFIRMED,
     write_authoritative_config,
     write_config,
@@ -3235,6 +3236,76 @@ def test_stlink_rejects_unconfirmed_successful_exit(tmp_path: Path) -> None:
     assert result["backend_error_type"] == "reset_unconfirmed"
 
 
+# What STM32CubeProgrammer prints when each reset mode's own command did what it
+# says. Two commands, two success lines: `-rst` announces the reset it drove,
+# `-halt` announces the core it stopped. Measured on v2.23.0 against a
+# NUCLEO-F446RE and modelled in fake_stlink.py.
+STLINK_RESET_SUCCESS_TEXT = {
+    "run": ["MCU Reset", "reset is performed"],
+    "halt": ["Core halted"],
+}
+
+
+@pytest.mark.parametrize("mode", sorted(STLINK_RESET_SUCCESS_TEXT))
+def test_stlink_confirms_each_reset_mode_on_the_lines_its_own_command_prints(tmp_path: Path, mode: str) -> None:
+    """Mode `halt` can report success at all, and mode `run` is untouched by that.
+
+    `halt` sends `-halt`, which prints neither line `-rst` prints, and the
+    backend asked for the `-rst` pair whichever mode was requested — so a halt
+    that did exactly what was asked came back `reset_failed` /
+    `reset_unconfirmed`, quarantining the bench over a correct call (#142).
+    Confirmation is still all-or-nothing; what changed is which set is
+    selected. The `run` row is the old set unchanged and is here to keep it
+    that way."""
+    config = load_config(str(write_config(tmp_path, debugger_type="stlink", probe_id="STLINK123")))
+    service = AgenticHILToolService(config)
+    try:
+        result = mcp_tool_call(service, "reset_target", {"mode": mode})
+    finally:
+        service.close()
+
+    assert result["ok"] is True, result
+    assert result["mode"] == mode
+    assert result["success_confirmed"] is True
+    assert result["operation_result"] == {"confirmed": True, "matched_success_text": STLINK_RESET_SUCCESS_TEXT[mode]}
+    assert result["summary"] == f"Target reset with mode '{mode}'."
+    assert result["side_effect_status"] == "committed"
+    assert result.get("quarantined") is not True, result
+    logged = json.loads((tmp_path / result["log_path"]).read_text(encoding="utf-8"))["command"]
+    assert BACKEND_RESET_COMMANDS[("stlink", mode)] in logged
+
+
+def test_a_halt_that_never_reported_the_core_stays_unconfirmed_however_much_the_connect_printed(tmp_path: Path) -> None:
+    """The connect banner is not a marker, and this is why.
+
+    This CLI connects, prints the whole banner including `Reset mode  :
+    Software reset` — the line that says mode `halt` resets before it halts —
+    and then never reports stopping the core. Connect runs before the halt is
+    attempted, so every line here is one a failed halt prints too; reading any
+    of them as confirmation would have confirmed exactly the run nobody can
+    account for. `Core halted` is the operation's own success line, it did not
+    arrive, and the result says so and quarantines."""
+    config = load_config(
+        str(write_config(tmp_path, debugger_type="stlink", debugger_executable=FAKE_STLINK_HALT_UNCONFIRMED)),
+    )
+    service = AgenticHILToolService(config)
+    try:
+        result = mcp_tool_call(service, "reset_target", {"mode": "halt"})
+    finally:
+        service.close()
+
+    assert result["ok"] is False, result
+    assert result["error_type"] == "reset_failed"
+    assert result["backend_error_type"] == "reset_unconfirmed"
+    assert result["operation_result"] == {"confirmed": False, "expected_success_text": ["Core halted"], "matched_success_text": []}
+    # Nothing on the host knows whether the core is halted or running, so this
+    # is the branch that stops the bench rather than one that refuses.
+    assert result["side_effect_status"] == "unknown"
+    assert result["quarantined"] is True
+    # The banner did print, and it confirmed nothing.
+    assert "Reset mode  : Software reset" in json.loads((tmp_path / result["log_path"]).read_text(encoding="utf-8"))["stdout"]
+
+
 def test_stlink_requires_flash_address_for_bin_artifacts(tmp_path: Path) -> None:
     firmware = tmp_path / "build" / "firmware.bin"
     firmware.parent.mkdir(parents=True)
@@ -3277,11 +3348,14 @@ def test_each_supported_reset_mode_sends_its_own_command_on_every_backend(tmp_pa
     that share a command line within one backend now fail here, whichever pair
     it is.
 
-    This asserts what went on the wire rather than `ok`, deliberately: mode
-    `halt` on stlink cannot be confirmed today, because STLINK_SUCCESS_CONFIRMATION
-    wants the two lines `-rst` prints and `-halt` prints neither. That is a
-    different defect from this one and is not fixed here - what this test has to
-    hold is that the argument reaching the CLI is the one the mode names."""
+    This asserts what went on the wire rather than `ok`, deliberately: what a
+    mode reports is a separate question from which command it sends, and the two
+    failed separately - stlink asked for the `-rst` confirmation lines whichever
+    mode ran, so `halt` sent the right command and could still never report
+    success (#142). That one is answered by
+    test_stlink_confirms_each_reset_mode_on_the_lines_its_own_command_prints;
+    what this test has to hold is that the argument reaching the CLI is the one
+    the mode names."""
     config = load_config(str(write_config(tmp_path, debugger_type=backend, probe_id=reset_probe_id(backend))))
     service = AgenticHILToolService(config)
     try:


### PR DESCRIPTION
Fixes #142.

`STLINK_RESET_MODES` holds, per mode, the wire argument and its measured success lines: `run` keeps the `-rst` pair unchanged; `halt` confirms on `Core halted`, taken from a captured STM32CubeProgrammer v2.23.0 transcript of the exact invocation the backend sends. The connect banner is deliberately not a marker — it prints before the halt is attempted, so it would confirm failures. The unconfirmed branch is untouched.

This also un-blocks recovery on stlink benches: the `reset_halt` policy calls this exact path, so automatic recovery could never attest a safe state there before.

Proof: the previously always-red halt plan now runs green on a real NUCLEO-F446RE, and the recovery path attested `reset_halt` on the same board. Suite 1707/38 Windows, 1713/32 containerized Linux; teeth by targeted revert (mode table reverted → exactly the two named tests fail).