### PR TITLE
chore(version): the cycle carries two versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Full history, which is what brings the tags. The check refuses a tree
+      # whose src/agentic_hil has moved past the release its version still
+      # claims, and the release tag is the only thing that can answer that
+      # offline. A tag it cannot reach is a warning rather than a failure, so
+      # with the default shallow fetch this job would report that it could not
+      # establish the thing it exists to establish, on every pull request, and
+      # pass.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # The Windows legs of the grown suite take about fourteen minutes of
+    # pytest alone; fifteen ended runs seconds after a green summary and
+    # reported the cancellation as a failure.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **Between releases a working tree shadowed the release it had moved past, and nothing downstream could tell them apart.** `src/agentic_hil` moves for a whole cycle while the version string stands still, so an install from such a tree reported the released number, `agentic-hil upgrade` called it `already_current`, and the install eval refused to run a local matrix at all rather than measure this tree and label it that release. The cycle now carries two versions: the release commit sets the final number, and the first commit after it moves the distribution version to `X.Y.Z.devN`. Only the two positions that identify the built artifact follow the tree, `pyproject.toml` and `src/agentic_hil/__init__.py`; every floor, install pin, published manifest and eval matrix keeps naming the release a reader can install. The version gate holds both shapes, refuses `--release-tag` on a development tree because a tag never carries a suffix, refuses a development version that does not follow the newest CHANGELOG heading, and refuses a tree whose package has moved past its release without saying so wherever the release tag is present to prove it, warning instead of failing in a fork or a shallow clone; the pre-merge job now fetches full history so the tag is there. The install eval expects the version an install actually produces, the tree's own for local and remote runs and the release for published ones. (#214)
+
 ## [0.13.0] - 2026-08-12
 
 ### Changed

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -18,6 +18,8 @@ major  breaking CLI, config, MCP, or report schema changes
 
 Keep releases small enough that each one has a clear theme and an obvious rollback path.
 
+A cycle carries two versions. The release commit sets the final number, and the first commit after it moves the distribution version to the next patch with a `.dev0` suffix, so a released `1.2.3` becomes `1.2.4.dev0` on the next commit. Only the two positions that identify the built artifact move with it: `pyproject.toml` and `src/agentic_hil/__init__.py`. Every other position `python tools/check_version_consistency.py --list` prints states a floor, an install pin or a published manifest, so it keeps naming the release a reader can actually install. Without the suffix, `src/agentic_hil` moves for a whole cycle while the version string stands still and a working tree becomes indistinguishable from the release it shadows: an install from it reports the released number, `agentic-hil upgrade` calls it `already_current`, and the install eval refuses to run a local matrix at all rather than report this tree as that release. The gate holds both shapes. On a release commit the two versions are one string and every check is the one it always was; between releases each position is compared against the version it is supposed to carry, `--release-tag` is refused outright because a tag never carries a suffix, and a tree whose package has moved past its release without saying so is refused where the release tag is present to prove it.
+
 ## Release Notes
 
 Each GitHub Release should include:
@@ -57,6 +59,7 @@ Before creating a release:
 8. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
 9. Verify the release appears as `io.github.agentic-hil/agentic-hil` in the MCP Registry API.
 10. Start from GitHub auto-generated release notes, then edit for clarity.
+11. Move the tree to the next development version in pyproject.toml and src/agentic_hil/__init__.py, in the first commit after the release. Every other position keeps naming the release just published.
 ```
 
 ## What the Release Gate Checks, and When
@@ -95,6 +98,13 @@ byte for byte against their contracts, and the sweep that refuses a file
 carrying the version that no check covers) is now settled before the merge.
 That matters because publishing is the point of no return: a PyPI version
 cannot be re-uploaded.
+
+One check reads git rather than files: the rule that a tree whose
+`src/agentic_hil` has moved past its release must carry a development version
+needs the release tag to compare against. The pre-merge job therefore checks out
+full history, and where the tag is genuinely absent (a fork, a shallow clone, an
+unpacked sdist) the check reports that it could not establish this and does not
+fail.
 
 ## Repository Protection
 

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -181,6 +181,15 @@ The remedy is a development version suffix on the working tree, or published
 mode against the release itself. A clone without that tag cannot answer the
 question, and says so on stderr rather than passing quietly.
 
+`expected_version` names the release in both matrices, because the same field is
+what a published-mode run pins and what the version gate holds every matrix to.
+Between releases the tree carries a development version, and an install from it
+reports that version, so local and remote runs expect the tree's own: what the
+verifier compares every artifact against is what the install produces. Published
+mode installs the release from the index and stays pinned to the release. It is
+also why the refusal above does not fire on a tree that carries a suffix, since
+nothing is being reported as the release any more.
+
 ## What decides a verdict
 
 Every job is one agent CLI, one model, one case, and one repetition. Each run

--- a/evals/install/runner.py
+++ b/evals/install/runner.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .config import Case, CredentialFile, Job, Matrix, load_matrix
+from .config import Case, CredentialFile, Job, Matrix, Target, load_matrix
 from .credentials import authentication_failure, credential_health
 from .redaction import DEFAULT_LOG_CONTENT_BYTES, RedactingLogWriter, redact, redact_value
 from .refresh_login import apply_refreshed_login
@@ -40,6 +40,10 @@ AGENT_CLI_PACKAGES = {
     "opencode": "opencode-ai",
 }
 TOOL_CONTRACT = Path("evals") / "install" / "tools.list.expected"
+# PEP 440's development release, which is what this tree carries between two
+# releases. `tools/check_version_consistency.py` owns the rule; here it is only
+# the shape that matters, because the question is what an install reports.
+DEVELOPMENT_VERSION = re.compile(r"^\d+\.\d+\.\d+\.dev\d+$")
 
 
 def utc_now() -> str:
@@ -77,7 +81,13 @@ def git_metadata(source_root: Path) -> dict[str, Any]:
         return {"revision": None, "dirty": None}
 
 
-def validate_source_version(source_root: Path, expected_version: str) -> None:
+def source_version(source_root: Path) -> str:
+    """What an install from this tree calls itself.
+
+    Not necessarily `target.expected_version`: between releases the tree carries
+    a development version while the matrix keeps naming the release, and this is
+    the number every artifact of a local install will actually report.
+    """
     try:
         import tomllib
     except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
@@ -85,8 +95,42 @@ def validate_source_version(source_root: Path, expected_version: str) -> None:
 
     data = tomllib.loads((source_root / "pyproject.toml").read_text(encoding="utf-8"))
     version = data.get("project", {}).get("version")
-    if version != expected_version:
+    if not isinstance(version, str) or not version:
+        raise ValueError("source pyproject.toml declares no [project] version")
+    return version
+
+
+def validate_source_version(source_root: Path, expected_version: str) -> str:
+    """Refuse a matrix this tree cannot answer for, and say what it installs as.
+
+    `target.expected_version` names the release, because the same field is what
+    a published-mode run pins and what the version gate holds every matrix to.
+    Between releases the tree is ahead of that release and says so with a
+    development suffix, so the two legitimately differ; which development
+    version follows which release is settled by
+    `tools/check_version_consistency.py` on every push, and the only thing worth
+    refusing here is a tree that is neither the release nor a development
+    version of anything.
+    """
+    version = source_version(source_root)
+    if version != expected_version and DEVELOPMENT_VERSION.match(version) is None:
         raise ValueError(f"source version {version!r} does not match target.expected_version {expected_version!r}")
+    return version
+
+
+def installed_version(target: Target, host_source_root: Path) -> str:
+    """The version an install for this target will report, and so what to expect.
+
+    Published mode installs the release from the index, and the release is what
+    the matrix names. Every other mode installs this tree: local from a snapshot
+    of it, remote from the commit `validate_remote_checkout` has already pinned
+    it to. What such an install reports is the tree's own version, development
+    suffix and all, and expecting anything else would fail every run in a cycle
+    or, worse, pass a tree off as the release it is not.
+    """
+    if target.mode == "published":
+        return target.expected_version
+    return source_version(host_source_root)
 
 
 def validate_remote_checkout(source_root: Path, expected_commit: str) -> None:
@@ -186,6 +230,11 @@ def validate_source_matches_release(source_root: Path, expected_version: str) ->
     release, and the digest the verifier compares against is the moved tree's
     own: self-consistent, and about the wrong thing.
 
+    Only for a tree that still claims the release. A tree carrying a development
+    version reports that version, from the wheel to the MCP server banner, so
+    there is no longer a release for it to be mistaken for and the caller does
+    not ask.
+
     The released digest comes from the tag in this clone rather than from the
     index, so the gate holds offline. A clone without the tag cannot answer, and
     says so rather than passing silently. Comparing an archive against a working
@@ -212,6 +261,24 @@ def validate_source_matches_release(source_root: Path, expected_version: str) ->
         )
 
 
+def source_gates(host_source_root: Path, target: Target) -> str:
+    """Everything the source tree must satisfy before the first container starts.
+
+    One place, because these three refusals are one question asked of one tree,
+    and the answer to the first decides whether the second applies: a tree
+    carrying a development version reports itself rather than the release, which
+    is the entire defect `validate_source_matches_release` exists to refuse. Left
+    in, it would refuse the ordinary state of every commit between two releases.
+    """
+    version = validate_source_version(host_source_root, target.expected_version)
+    if target.mode == "local" and version == target.expected_version:
+        validate_source_matches_release(host_source_root, target.expected_version)
+    if target.mode == "remote":
+        assert target.expected_commit is not None
+        validate_remote_checkout(host_source_root, target.expected_commit)
+    return version
+
+
 def job_payload(
     matrix: Matrix,
     case: Case,
@@ -220,6 +287,10 @@ def job_payload(
     host_source_root: Path,
 ) -> dict[str, Any]:
     target = dataclasses.asdict(matrix.target)
+    # What the verifier compares every artifact against: the version this
+    # target's install actually produces, which for anything but published mode
+    # is the tree's own and not the release the matrix names.
+    target["expected_version"] = installed_version(matrix.target, host_source_root)
     if matrix.target.mode == "local":
         if source_root is None:
             raise ValueError("target requires trusted source evidence")
@@ -1253,12 +1324,7 @@ def run_matrix(args: argparse.Namespace) -> int:
     if args.per_model_concurrency < 1:
         raise RuntimeError("per-model concurrency must be at least 1")
     host_source_root = Path(args.source_root).resolve()
-    validate_source_version(host_source_root, matrix.target.expected_version)
-    if matrix.target.mode == "local":
-        validate_source_matches_release(host_source_root, matrix.target.expected_version)
-    if matrix.target.mode == "remote":
-        assert matrix.target.expected_commit is not None
-        validate_remote_checkout(host_source_root, matrix.target.expected_commit)
+    source_gates(host_source_root, matrix.target)
     docker = shutil.which(args.docker) or args.docker
 
     with contextlib.ExitStack() as stack:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.13.0"
+version = "0.13.1.dev0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.13.0"
+__version__ = "0.13.1.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -1945,9 +1945,13 @@ def test_skill_frontmatter_survives_a_windows_checkout() -> None:
     crlf = _packaged_skill_text().replace("\n", "\r\n")
 
     assert is_agentic_hil_setup_skill(crlf)
-    # Against the package version, not against the same function's own output:
-    # comparing two computed values passes when both are None.
-    assert skill_version(crlf) == __version__
+    # Not against `__version__`: that is the distribution version, which runs
+    # ahead of the release for a whole cycle, while a skill states the release
+    # it belongs to. Pinned as not-None first, because comparing two computed
+    # values passes when both are None.
+    stated = skill_version(_packaged_skill_text())
+    assert stated is not None
+    assert skill_version(crlf) == stated
 
 
 def test_plugin_skill_carries_the_packaged_guidance() -> None:

--- a/tests/test_install_eval.py
+++ b/tests/test_install_eval.py
@@ -1149,6 +1149,69 @@ def test_a_clone_without_the_release_tag_says_it_cannot_check(
     assert "no v0.9.9 tag" in capsys.readouterr().err
 
 
+def _states_version(root: Path, version: str) -> None:
+    """The minimum of a source tree, as far as the version gates read one."""
+    (root / "pyproject.toml").write_text(f'[project]\nname = "agentic-hil"\nversion = "{version}"\n', encoding="utf-8")
+
+
+def test_a_development_tree_is_expected_at_the_version_it_installs_as(tmp_path: Path) -> None:
+    """The honest contract: expect what the install produces, not what it names.
+
+    `target.expected_version` names the release, because the same field is what
+    a published-mode run pins and what the version gate holds both committed
+    matrices to. A local install from a tree that has moved past that release
+    yields the development version, and every artifact of the run reports it, so
+    that is what the verifier is given. The moved-tree refusal does not fire:
+    nothing here is being reported as the release.
+    """
+    from evals.install.config import Target
+    from evals.install.runner import installed_version, source_gates
+
+    _tagged_package_repository(tmp_path, "0.4.0", b"version = 1\n")
+    (tmp_path / "src" / "agentic_hil" / "__init__.py").write_bytes(b"version = 2\n")
+    _states_version(tmp_path, "0.4.1.dev0")
+    target = Target(mode="local", expected_version="0.4.0")
+
+    assert source_gates(tmp_path, target) == "0.4.1.dev0"
+    assert installed_version(target, tmp_path) == "0.4.1.dev0"
+
+
+def test_a_moved_tree_still_claiming_the_release_is_still_refused(tmp_path: Path) -> None:
+    """The other half: without the suffix, the run would report a lie."""
+    from evals.install.config import Target
+    from evals.install.runner import source_gates
+
+    _tagged_package_repository(tmp_path, "0.4.0", b"version = 1\n")
+    (tmp_path / "src" / "agentic_hil" / "__init__.py").write_bytes(b"version = 2\n")
+    _states_version(tmp_path, "0.4.0")
+
+    with pytest.raises(ValueError, match="has moved since v0.4.0"):
+        source_gates(tmp_path, Target(mode="local", expected_version="0.4.0"))
+
+
+def test_a_published_run_stays_pinned_to_the_release(tmp_path: Path) -> None:
+    """Nothing of this tree reaches a published run; the index answers it."""
+    from evals.install.config import Target
+    from evals.install.runner import installed_version
+
+    _states_version(tmp_path, "0.4.1.dev0")
+    target = Target(mode="published", expected_version="0.4.0", guide_url="https://example.invalid/guide")
+
+    assert installed_version(target, tmp_path) == "0.4.0"
+
+
+def test_a_tree_that_is_neither_the_release_nor_a_development_version_is_refused(tmp_path: Path) -> None:
+    """The refusal that stays: a matrix this tree cannot answer for at all."""
+    from evals.install.config import Target
+    from evals.install.runner import source_gates
+
+    _tagged_package_repository(tmp_path, "0.4.0", b"version = 1\n")
+    _states_version(tmp_path, "0.9.9")
+
+    with pytest.raises(ValueError, match="does not match target.expected_version"):
+        source_gates(tmp_path, Target(mode="local", expected_version="0.4.0"))
+
+
 def test_the_guide_link_is_handed_through_verbatim(tmp_path: Path) -> None:
     """What an engineer pastes is a link, and the guide's own path takes it from there."""
     link = "https://github.com/agentic-hil/agentic-hil/blob/master/AI_AGENT_QUICKSTART.md"

--- a/tests/test_install_eval_cleanup.py
+++ b/tests/test_install_eval_cleanup.py
@@ -14,6 +14,9 @@ def _source_tree(root: Path) -> Path:
     package = root / "src" / "agentic_hil"
     package.mkdir(parents=True)
     (package / "__init__.py").write_text('__version__ = "0.4.0"\n', encoding="utf-8")
+    # What an install from this tree would call itself, and so what the runner
+    # tells the verifier to expect. A source tree without it installs as nothing.
+    (root / "pyproject.toml").write_text('[project]\nname = "agentic-hil"\nversion = "0.4.0"\n', encoding="utf-8")
     contract = root / "evals" / "install" / "tools.list.expected"
     contract.parent.mkdir(parents=True)
     contract.write_text("probe_target\n", encoding="utf-8")

--- a/tests/test_install_eval_contract.py
+++ b/tests/test_install_eval_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import dataclasses
 import hashlib
 import re
 from dataclasses import fields
@@ -20,7 +21,7 @@ from agentic_hil.types import (
 from evals.install import verifier
 from evals.install.config import load_case, load_matrix
 from evals.install.fixtures import HARDWARE_MAKE_TARGETS, MAKE_FLASH_FILES
-from evals.install.runner import expected_mcp_tools, job_payload
+from evals.install.runner import expected_mcp_tools, job_payload, source_version
 from evals.install.verifier import target_mcp_tools
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -108,6 +109,23 @@ def test_every_agent_session_receives_the_reasoning_effort() -> None:
     assert len(calls) == 3, "one call per agent session: install, confirmation, follow-up"
     for call in calls:
         assert any(keyword.arg == "reasoning_effort" for keyword in call.keywords)
+
+
+def test_the_payload_expects_what_the_install_produces_not_what_the_matrix_names() -> None:
+    """The one field the runner overrides on its way into the container.
+
+    A local run installs this tree, so the version every artifact reports is the
+    tree's own. Between releases that is a development version while the matrix
+    still names the release, and handing the matrix's number to the verifier
+    would fail every check that reads a version, in every run, for a whole cycle.
+    """
+    matrix = load_matrix(REPOSITORY_ROOT / "evals" / "install" / "matrix.example.json")
+    misnamed = dataclasses.replace(matrix, target=dataclasses.replace(matrix.target, expected_version="0.0.1"))
+
+    payload = job_payload(misnamed, misnamed.cases[0], misnamed.jobs[0], REPOSITORY_ROOT, REPOSITORY_ROOT)
+
+    assert payload["target"]["expected_version"] == source_version(REPOSITORY_ROOT)
+    assert payload["target"]["expected_version"] != "0.0.1"
 
 
 def test_job_binds_mcp_contract_from_target_source() -> None:

--- a/tests/test_shipped_references.py
+++ b/tests/test_shipped_references.py
@@ -8,7 +8,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
-from check_shipped_references import main, shipped_documents, violations  # noqa: E402
+from check_shipped_references import main, package_version, shipped_documents, violations  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -30,11 +30,34 @@ def test_the_gate_runs_on_every_python_this_project_supports() -> None:
             modules.add(node.module.split(".")[0])
 
     assert "tomllib" not in modules
-    assert modules <= {"__future__", "ast", "re", "sys", "pathlib"}, sorted(modules)
+    # check_version_consistency is the other half of the same gate and imports
+    # nothing outside the standard library either. It is here because it owns
+    # the one question this file must not answer twice: which version a pin
+    # names when the tree it is read from carries a development suffix.
+    assert modules <= {"__future__", "check_version_consistency", "re", "sys", "pathlib"}, sorted(modules)
 
 
 def test_the_repository_ships_no_reference_a_reader_must_not_copy() -> None:
     assert main([str(REPOSITORY_ROOT)]) == 0
+
+
+def test_a_pin_is_compared_against_the_release_and_never_against_this_tree(tmp_path: Path) -> None:
+    """Between releases the tree is ahead of everything a reader can install.
+
+    The tag pin in TROUBLESHOOTING.md is the documented route while PyPI is
+    unreachable, so it names the release. Comparing it against the development
+    version this tree builds would call the one correct pin in the repository
+    wrong, on every commit of every cycle.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "agentic-hil"\nversion = "1.2.4.dev0"\n', encoding="utf-8"
+    )
+    (tmp_path / "CHANGELOG.md").write_text("## [1.2.3] - 2020-01-01\n\nThe release.\n", encoding="utf-8")
+
+    version = package_version(tmp_path)
+
+    assert version == "1.2.3"
+    assert violations(Path("doc.md"), 'uv tool install "git+https://github.com/agentic-hil/agentic-hil@v1.2.3"', version) == []
 
 
 def test_every_document_a_reader_receives_is_covered() -> None:

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -4,6 +4,7 @@ import ast
 import json
 import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -12,16 +13,24 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
 from check_version_consistency import (  # noqa: E402
+    DISTRIBUTION,
+    RELEASE,
     UNTRACKED_MENTIONS,
     contract_problems,
+    is_development,
+    is_newer,
     locations,
     main,
+    moved_tree_findings,
+    next_development_version,
     package_version,
     problems,
+    release_version,
     render_list,
     unclaimed_pins,
     uncovered_files,
     version_problems,
+    warnings,
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -33,6 +42,8 @@ def test_the_gate_runs_on_every_python_this_project_supports() -> None:
 
     The version gate now blocks the merge, so a gate that cannot import on a
     matrix leg would block every merge on that leg instead of catching anything.
+    `packaging` is on the same list for the same reason: it is not stdlib at all,
+    which is why the two version shapes are ordered inside the module.
     """
     source = (REPOSITORY_ROOT / CHECK).read_text(encoding="utf-8")
     modules = set()
@@ -43,7 +54,20 @@ def test_the_gate_runs_on_every_python_this_project_supports() -> None:
             modules.add(node.module.split(".")[0])
 
     assert "tomllib" not in modules
-    assert modules <= {"__future__", "ast", "json", "re", "sys", "dataclasses", "pathlib"}, sorted(modules)
+    assert "packaging" not in modules
+    # subprocess joined the list with the rule that a tree which has moved past
+    # its release must say so: the release tag is the only thing that can answer
+    # that offline, and git is what holds it.
+    assert modules <= {
+        "__future__",
+        "ast",
+        "json",
+        "re",
+        "subprocess",
+        "sys",
+        "dataclasses",
+        "pathlib",
+    }, sorted(modules)
 
 
 def test_this_tree_agrees_with_itself() -> None:
@@ -73,10 +97,23 @@ def test_the_release_carries_its_version_where_the_release_that_exposed_this_car
 
 
 def test_every_stated_position_actually_carries_a_version() -> None:
-    version = package_version(REPOSITORY_ROOT)
+    distribution = package_version(REPOSITORY_ROOT)
+    release = release_version(REPOSITORY_ROOT)
     for location in locations(REPOSITORY_ROOT):
         assert location.versions, f"{location.path} states no version"
-        assert set(location.versions) == {version}, location
+        expected = distribution if location.tracks == DISTRIBUTION else release
+        assert set(location.versions) == {expected}, location
+
+
+def test_only_the_two_positions_that_identify_the_artifact_track_the_tree() -> None:
+    """The named exception list, read off the check rather than off a brief.
+
+    Everything else states a floor, an install pin or a published manifest: what
+    a reader gets when they install, which is the release and never this tree.
+    """
+    tracked = {location.path for location in locations(REPOSITORY_ROOT) if location.tracks == DISTRIBUTION}
+
+    assert tracked == {"pyproject.toml", "src/agentic_hil/__init__.py"}
 
 
 def test_the_troubleshooting_pins_are_all_of_them() -> None:
@@ -135,6 +172,50 @@ def tree(tmp_path: Path) -> Path:
     return root
 
 
+def _set_distribution_version(root: Path, version: str) -> None:
+    """Move the two positions that identify the built artifact, and only those."""
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text(
+        re.sub(
+            r'^version = "[^"]+"',
+            f'version = "{version}"',
+            pyproject.read_text(encoding="utf-8"),
+            count=1,
+            flags=re.MULTILINE,
+        ),
+        encoding="utf-8",
+    )
+    init = root / "src" / "agentic_hil" / "__init__.py"
+    init.write_text(
+        re.sub(
+            r'^__version__ = "[^"]+"',
+            f'__version__ = "{version}"',
+            init.read_text(encoding="utf-8"),
+            count=1,
+            flags=re.MULTILINE,
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def released_tree(tree: Path) -> Path:
+    """A release commit: one version, stated everywhere, as it always was.
+
+    Built from the copy rather than assumed of it, so these tests say what they
+    mean whichever shape `master` happens to carry when they run.
+    """
+    _set_distribution_version(tree, release_version(tree))
+    return tree
+
+
+@pytest.fixture
+def development_tree(tree: Path) -> Path:
+    """The commit after a release: the tree moved on, the release positions did not."""
+    _set_distribution_version(tree, next_development_version(release_version(tree)))
+    return tree
+
+
 def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
     assert version_problems(tree) == []
     assert contract_problems(tree) == []
@@ -143,53 +224,62 @@ def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("relative", "replace", "names"),
+    ("relative", "tracks", "replace", "names"),
     [
         # pyproject.toml is the reference every other position is compared with,
         # so moving it alone reports the other eleven rather than itself. Either
         # way the tree is refused, which is what a release depends on.
         (
             "pyproject.toml",
+            DISTRIBUTION,
             lambda text, version: text.replace(f'version = "{version}"', 'version = "9.9.9"', 1),
             "but this release is 9.9.9",
         ),
         (
             "src/agentic_hil/__init__.py",
+            DISTRIBUTION,
             lambda text, version: text.replace(f'__version__ = "{version}"', '__version__ = "9.9.9"'),
             "src/agentic_hil/__init__.py",
         ),
         (
             "server.json",
+            RELEASE,
             lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"', 1),
             "server.json",
         ),
         (
             "plugins/agentic-hil/.claude-plugin/plugin.json",
+            RELEASE,
             lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"'),
             "plugins/agentic-hil/.claude-plugin/plugin.json",
         ),
         (
             ".claude-plugin/marketplace.json",
+            RELEASE,
             lambda text, version: text.replace(f'"version": "{version}"', '"version": "9.9.9"'),
             ".claude-plugin/marketplace.json",
         ),
         (
             "CHANGELOG.md",
+            RELEASE,
             lambda text, version: text.replace(f"## [{version}]", "## [9.9.9]", 1),
             "CHANGELOG.md",
         ),
         (
             "src/agentic_hil/skills/agentic-hil/SKILL.md",
+            RELEASE,
             lambda text, version: text.replace(version, "9.9.9", 1),
             "src/agentic_hil/skills/agentic-hil/SKILL.md",
         ),
         (
             "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
+            RELEASE,
             lambda text, version: text.replace(f"agentic-hil=={version}", "agentic-hil==9.9.9"),
             "plugins/agentic-hil/skills/agentic-hil/SKILL.md",
         ),
         (
             "TROUBLESHOOTING.md",
+            RELEASE,
             lambda text, version: text.replace(f"agentic-hil>={version}", "agentic-hil>=9.9.9", 1),
             "TROUBLESHOOTING.md",
         ),
@@ -197,33 +287,47 @@ def test_the_copied_tree_is_a_fair_starting_point(tree: Path) -> None:
         # a requirement pin and went unchecked while the file counted as covered.
         (
             "TROUBLESHOOTING.md",
+            RELEASE,
             lambda text, version: text.replace(f"agentic-hil@v{version}", "agentic-hil@v0.6.0", 1),
             "TROUBLESHOOTING.md states 0.6.0",
         ),
         (
             "evals/install/matrix.example.json",
+            RELEASE,
             lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
             "evals/install/matrix.example.json",
         ),
         (
             "evals/install/matrix.full.json",
+            RELEASE,
             lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
             "evals/install/matrix.full.json",
         ),
         (
             "evals/install/README.md",
+            RELEASE,
             lambda text, version: text.replace(f'"expected_version": "{version}"', '"expected_version": "9.9.9"'),
             "evals/install/README.md",
         ),
     ],
 )
-def test_one_position_out_of_step_fails(tree: Path, relative: str, replace, names: str) -> None:
+@pytest.mark.parametrize("shape", ["released_tree", "development_tree"])
+def test_one_position_out_of_step_fails(
+    request: pytest.FixtureRequest,
+    shape: str,
+    relative: str,
+    tracks: str,
+    replace,
+    names: str,
+) -> None:
     """The proof. Break the version in exactly one file and the check goes red.
 
     Every position in turn, because a check that covers eleven of twelve is the
-    thing this replaced.
+    thing this replaced, and in both tree shapes, because the two-version world
+    doubled the number of ways a position can be compared against the wrong one.
     """
-    version = package_version(tree)
+    tree = request.getfixturevalue(shape)
+    version = package_version(tree) if tracks == DISTRIBUTION else release_version(tree)
     path = tree / relative
     broken = replace(path.read_text(encoding="utf-8"), version)
     assert broken != path.read_text(encoding="utf-8"), f"the test did not actually change {relative}"
@@ -261,6 +365,25 @@ def test_a_new_home_for_the_version_cannot_appear_unnoticed(tree: Path) -> None:
     assert found
     assert "docs/installation.md" in found[0]
     assert CHECK in found[0]
+
+
+def test_a_new_home_for_the_development_version_cannot_appear_either(development_tree: Path) -> None:
+    """The sweep learned the second version, or half of it would be unwatched.
+
+    A document that pins the tree's own development version is a document
+    telling a reader to install something that was never released, and it is
+    exactly the mistake a version bump invites.
+    """
+    (development_tree / "docs").mkdir(parents=True, exist_ok=True)
+    (development_tree / "docs" / "installation.md").write_text(
+        f'pip install "agentic-hil=={package_version(development_tree)}"\n', encoding="utf-8"
+    )
+
+    found = uncovered_files(development_tree)
+
+    assert found
+    assert "docs/installation.md" in found[0]
+    assert package_version(development_tree) in found[0]
 
 
 def test_a_deliberate_mention_is_declared_rather_than_forgotten(tree: Path) -> None:
@@ -355,12 +478,99 @@ def test_a_version_inside_a_longer_number_is_not_a_mention(tree: Path) -> None:
     assert uncovered_files(tree) == []
 
 
+def test_a_release_shaped_tree_is_the_check_it_always_was(released_tree: Path) -> None:
+    """One version, in every position, and no development suffix anywhere."""
+    assert problems(released_tree) == []
+    assert not is_development(package_version(released_tree))
+    assert release_version(released_tree) == package_version(released_tree)
+
+
+def test_the_tree_after_a_release_states_two_versions_and_passes(development_tree: Path) -> None:
+    """The shape every commit between two releases carries.
+
+    The distribution positions name the tree, the release positions keep naming
+    the release a reader can install, and the gate is silent: that is the whole
+    of the decision, checked rather than described.
+    """
+    distribution = package_version(development_tree)
+    release = release_version(development_tree)
+
+    assert is_development(distribution)
+    assert distribution != release
+    assert problems(development_tree) == []
+    for location in locations(development_tree):
+        expected = distribution if location.tracks == DISTRIBUTION else release
+        assert set(location.versions) == {expected}, location
+
+
+def test_a_development_version_that_does_not_follow_the_release_is_refused(development_tree: Path) -> None:
+    """The suffix extends the newest release; it cannot precede or repeat it.
+
+    `1.2.3.dev1` is not "after 1.2.3", it is a pre-release *of* it, which is how
+    a tree could carry a suffix and still shadow the release it claims to have
+    moved past.
+    """
+    release = release_version(development_tree)
+    _set_distribution_version(development_tree, f"{release}.dev1")
+
+    found = version_problems(development_tree)
+
+    assert found
+    assert "does not follow it" in found[0]
+    assert release in found[0]
+
+
+@pytest.mark.parametrize(
+    ("version", "other"),
+    [
+        # Synthetic numbers throughout: a test that spelled out the current
+        # release would itself become a file carrying the version, which the
+        # sweep refuses and rightly so.
+        ("1.2.4.dev0", "1.2.3"),
+        ("1.2.4.dev1", "1.2.4.dev0"),
+        ("1.3.0.dev0", "1.2.9"),
+        ("2.0.0.dev0", "1.99.99"),
+        ("1.2.4", "1.2.4.dev0"),
+    ],
+)
+def test_a_development_version_orders_the_way_pep_440_says(version: str, other: str) -> None:
+    """The ordering the whole decision rests on, and it is not string order.
+
+    A development release is newer than every earlier release and older than the
+    one it anticipates. Every installer and every `>=` floor reads it this way,
+    which is why a suffixed tree can be published, resolved and upgraded from
+    without anything downstream learning a new rule.
+    """
+    assert is_newer(version, other)
+    assert not is_newer(other, version)
+
+
+def test_the_suffix_the_gate_suggests_is_the_one_that_follows_the_release() -> None:
+    assert next_development_version("1.2.3") == "1.2.4.dev0"
+    assert is_newer(next_development_version("1.2.3"), "1.2.3")
+
+
 @pytest.mark.parametrize("tag", ["v9.9.9", "9.9.9"])
 def test_a_tag_that_is_not_this_version_fails(tree: Path, tag: str) -> None:
     found = version_problems(tree, release_tag=tag)
 
     assert found
     assert "release tag" in found[0]
+
+
+def test_a_release_tag_is_refused_outright_on_a_development_tree(development_tree: Path) -> None:
+    """A tag never carries a development suffix, so this path never sees one.
+
+    The release job runs the same module with `--release-tag` after the release
+    exists. Reaching it from a tree that never stopped being between releases
+    means the release was cut from the wrong commit, and PyPI cannot take a
+    version back.
+    """
+    version = package_version(development_tree)
+
+    for tag in (f"v{version}", version, f"v{release_version(development_tree)}"):
+        found = version_problems(development_tree, release_tag=tag)
+        assert any("cannot be cut from a development tree" in problem for problem in found), tag
 
 
 @pytest.mark.parametrize("tag", ["", None])
@@ -443,3 +653,109 @@ def test_the_printed_list_names_every_position_and_its_count() -> None:
 def test_an_unknown_option_is_refused() -> None:
     with pytest.raises(SystemExit):
         main(["--publish"])
+
+
+def _checkout(root: Path, tag: str | None) -> None:
+    """Commit this tree, and tag it as the release it states.
+
+    The line-ending pin this repository carries, because the comparison the
+    check makes is a `git diff` against a tag and a machine with
+    core.autocrlf=true would otherwise read every file as changed.
+    """
+    (root / ".gitattributes").write_text("* text=auto eol=lf\n", encoding="utf-8")
+    commands = [
+        ["init", "--initial-branch=main"],
+        ["add", "-A"],
+        ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "release"],
+    ]
+    if tag is not None:
+        commands.append(["tag", tag])
+    for command in commands:
+        result = subprocess.run(["git", "-C", str(root), *command], capture_output=True)
+        assert result.returncode == 0, result.stderr
+
+
+def test_a_package_that_moved_past_its_release_must_carry_a_development_version(released_tree: Path) -> None:
+    """The rule that makes the suffix a rule rather than a habit.
+
+    A tree whose package has moved while its version stands still is
+    indistinguishable from the release it shadows, which is what an install, an
+    upgrade and the install eval all get wrong at once.
+    """
+    release = release_version(released_tree)
+    _checkout(released_tree, f"v{release}")
+    assert problems(released_tree) == []
+
+    package = released_tree / "src" / "agentic_hil" / "__init__.py"
+    package.write_text(package.read_text(encoding="utf-8") + "\n# a change nobody released\n", encoding="utf-8")
+
+    found, notes = moved_tree_findings(released_tree)
+
+    assert notes == []
+    assert found
+    assert f"has moved since v{release}" in found[0]
+    assert next_development_version(release) in found[0]
+    assert found[0] in problems(released_tree)
+
+
+def test_a_file_nothing_has_added_yet_is_a_moved_package_too(released_tree: Path) -> None:
+    """`git diff` cannot see an untracked file, and a new module is one."""
+    _checkout(released_tree, f"v{release_version(released_tree)}")
+
+    (released_tree / "src" / "agentic_hil" / "newcomer.py").write_text("value = 1\n", encoding="utf-8")
+
+    found, notes = moved_tree_findings(released_tree)
+
+    assert notes == []
+    assert found
+
+
+def test_the_suffix_is_what_lets_the_package_move(development_tree: Path) -> None:
+    """The other side of the rule: with the suffix, moving on is the point."""
+    _checkout(development_tree, f"v{release_version(development_tree)}")
+
+    package = development_tree / "src" / "agentic_hil" / "__init__.py"
+    package.write_text(package.read_text(encoding="utf-8") + "\n# the work this cycle\n", encoding="utf-8")
+
+    assert moved_tree_findings(development_tree) == ([], [])
+    assert problems(development_tree) == []
+
+
+def test_a_clone_without_the_release_tag_warns_rather_than_fails(released_tree: Path) -> None:
+    """A fork and a shallow clone did nothing wrong and must not go red.
+
+    The tag is the only thing that can say offline what the release shipped, so
+    where it is absent the answer is that nobody asked, not that somebody erred.
+    """
+    _checkout(released_tree, tag=None)
+    package = released_tree / "src" / "agentic_hil" / "__init__.py"
+    package.write_text(package.read_text(encoding="utf-8") + "\n# a change nobody released\n", encoding="utf-8")
+
+    found, notes = moved_tree_findings(released_tree)
+
+    assert found == []
+    assert problems(released_tree) == []
+    assert notes
+    assert f"v{release_version(released_tree)} is not reachable here" in notes[0]
+    assert notes == warnings(released_tree)
+
+
+def test_a_tree_that_is_no_checkout_at_all_is_a_warning(released_tree: Path) -> None:
+    """An unpacked sdist has the files and no history to compare them against."""
+    found, notes = moved_tree_findings(released_tree)
+
+    assert found == []
+    assert notes
+
+
+def test_the_release_metadata_job_fetches_the_tags_the_check_needs() -> None:
+    """Without the tags the new rule reports that it could not check, and passes.
+
+    `actions/checkout` fetches one commit and no tags by default, which is
+    exactly the condition the check treats as unanswerable.
+    """
+    ci = (REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    job = ci.split("  release_metadata:", 1)[1].split("\n  audit:", 1)[0]
+
+    assert "fetch-depth: 0" in job
+    assert f"python {CHECK}" in job

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -470,10 +470,12 @@ def test_a_third_party_action_pin_is_not_this_projects_version(tree: Path) -> No
 
 
 def test_a_version_inside_a_longer_number_is_not_a_mention(tree: Path) -> None:
-    version = package_version(tree)
-    major, minor, patch = version.split(".")
+    """Both versions the sweep looks for, and a digit on either side of each."""
+    swept = {release_version(tree), package_version(tree)}
     (tree / "docs").mkdir(parents=True, exist_ok=True)
-    (tree / "docs" / "numbers.md").write_text(f"1{version} and {major}.{minor}.{patch}9\n", encoding="utf-8")
+    (tree / "docs" / "numbers.md").write_text(
+        "\n".join(f"1{version} and {version}9" for version in sorted(swept)) + "\n", encoding="utf-8"
+    )
 
     assert uncovered_files(tree) == []
 
@@ -579,11 +581,12 @@ def test_no_tag_is_not_a_failure(tree: Path, tag: str | None) -> None:
     assert version_problems(tree, release_tag=tag) == []
 
 
-def test_the_release_tag_is_accepted_with_and_without_its_v(tree: Path) -> None:
-    version = package_version(tree)
+def test_the_release_tag_is_accepted_with_and_without_its_v(released_tree: Path) -> None:
+    """A release commit, because that is the only tree a tag is ever cut from."""
+    version = package_version(released_tree)
 
-    assert version_problems(tree, release_tag=f"v{version}") == []
-    assert version_problems(tree, release_tag=version) == []
+    assert version_problems(released_tree, release_tag=f"v{version}") == []
+    assert version_problems(released_tree, release_tag=version) == []
 
 
 @pytest.mark.parametrize(

--- a/tools/check_shipped_references.py
+++ b/tools/check_shipped_references.py
@@ -13,10 +13,11 @@ merging. It runs in CI on every push and pull request, and again at release.
 
 from __future__ import annotations
 
-import ast
 import re
 import sys
 from pathlib import Path
+
+from check_version_consistency import release_version
 
 IMMUTABLE_REFERENCE = re.compile(r"^(v\d+\.\d+\.\d+|[0-9a-f]{40})$")
 # Anchored at the repository URL: "agentic-hil@agentic-hil" is the
@@ -29,19 +30,19 @@ INSTALLS_FROM_SOURCE = re.compile(r"git\+https://github\.com/agentic-hil/agentic
 
 
 def package_version(root: Path) -> str:
-    """Read __version__ rather than pyproject.
+    """The release a pin must name, which is not the version this tree builds.
 
-    tomllib is stdlib only from 3.11 and this project still supports 3.10, so a
-    TOML parse would make the gate itself the thing that fails. The release job
-    already refuses a build where the two disagree.
+    Between releases the distribution version carries a development suffix while
+    every pin a reader copies keeps naming the release they can actually install,
+    so a tag pin here must be compared against the release and never against the
+    tree. That distinction has exactly one owner, `check_version_consistency`,
+    which the release strategy already names as the single enforcement point for
+    version agreement; a second answer to the same question in this file is how
+    the enumeration it replaced drifted in the first place. It imports nothing
+    outside the standard library either, so this gate still runs on the oldest
+    Python the project supports.
     """
-    tree = ast.parse((root / "src" / "agentic_hil" / "__init__.py").read_text(encoding="utf-8"))
-    for node in tree.body:
-        if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets
-        ):
-            return str(ast.literal_eval(node.value))
-    raise SystemExit("src/agentic_hil/__init__.py declares no __version__")
+    return release_version(root)
 
 
 def shipped_documents(root: Path) -> list[Path]:

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -742,7 +742,7 @@ def render_list(root: Path) -> str:
     # Distinct paths, not entries: a file may hold several claims — TROUBLESHOOTING.md
     # carries requirement pins and a git-tag pin as two entries.
     files = len({location.path for location in carried})
-    built = f", built as {distribution}" if distribution != release else ""
+    built = f" (built as {distribution})" if distribution != release else ""
     lines = [f"Release version {release}{built} is carried in {files} files, {occurrences} occurrences:", ""]
     for location in carried:
         count = len(location.versions)

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -27,9 +27,23 @@ TROUBLESHOOTING.md drifted by hand through four releases that way. Tag pins are
 now an entry of their own, and `unclaimed_pins` refuses a covered file whose
 project-tied `@v` pins its entries do not state.
 
+A tree carries two versions, not one. Between releases `src/agentic_hil` moves
+while the version string stands still, so for that whole window a working tree
+shadows a published release: an install from it reports the released number, and
+nothing downstream can tell the two apart. The first commit after each release
+therefore moves the *distribution* version, which is what a build of this tree
+calls itself, to a `.devN` development version, while every position that states
+a FLOOR or an install pin for users keeps naming the release they can actually
+install. `Location.tracks` says which of the two each position carries, and that
+field is the whole of the rule: on a tree without a suffix the two versions are
+the same string and everything behaves exactly as it did.
+
 tomllib is deliberately absent: it is stdlib only from 3.11 and this project
 still supports 3.10, so importing it would make the gate itself the thing that
-fails on a matrix leg the developer machine never runs.
+fails on a matrix leg the developer machine never runs. `packaging` is absent for
+a stronger version of the same reason, being no part of the standard library at
+all, so the two version shapes this project uses are ordered here, in
+`_ordering_key`.
 """
 
 from __future__ import annotations
@@ -37,13 +51,20 @@ from __future__ import annotations
 import ast
 import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
+PACKAGE = "src/agentic_hil"
+
 RELEASE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+# The distribution version between releases. PEP 440 spells a development
+# release `X.Y.Z.devN`, which sorts after every earlier release and before the
+# `X.Y.Z` it anticipates.
+DEVELOPMENT_VERSION = re.compile(r"^(?P<release>\d+\.\d+\.\d+)\.dev(?P<serial>\d+)$")
 # An optional leading "v" so a tag pin is seen, and no word character or dot on
 # either side so "1.2.3" is not read out of "11.2.3" or "1.2.30".
 SEMVER = re.compile(r"(?<![\w.])v?(\d+\.\d+\.\d+)(?![\w.])")
@@ -138,13 +159,22 @@ UNTRACKED_MENTIONS: dict[str, str] = {
 }
 
 
+# Which of the two versions a position states. RELEASE is the release users can
+# install: a floor, an install pin, a manifest a registry serves, the version an
+# eval installs from the index. DISTRIBUTION is what a build of *this tree*
+# calls itself, which between releases is ahead of the release and says so.
+RELEASE = "release"
+DISTRIBUTION = "distribution"
+
+
 @dataclass(frozen=True)
 class Location:
-    """One place that carries the release version."""
+    """One place that carries a version, and which of the two it carries."""
 
     path: str
     carries: str
     versions: tuple[str, ...] = ()
+    tracks: str = RELEASE
 
 
 def _read(root: Path, relative: str) -> str:
@@ -172,10 +202,45 @@ def _project_table(root: Path) -> dict[str, str]:
 
 
 def package_version(root: Path) -> str:
+    """The distribution version: what a build of this tree calls itself.
+
+    Either a strict SemVer release, on a release commit, or the `X.Y.Z.devN`
+    that every commit between two releases carries.
+    """
     version = _project_table(root).get("version")
-    if version is None or not RELEASE_VERSION.match(version):
-        raise SystemExit("pyproject.toml [project] declares no strict SemVer version")
+    if version is None or not (RELEASE_VERSION.match(version) or DEVELOPMENT_VERSION.match(version)):
+        raise SystemExit("pyproject.toml [project] declares no strict SemVer or X.Y.Z.devN version")
     return version
+
+
+def is_development(version: str) -> bool:
+    return DEVELOPMENT_VERSION.match(version) is not None
+
+
+def _ordering_key(version: str) -> tuple[int, int, int, int, int]:
+    """PEP 440 ordering for the two shapes this project uses.
+
+    A development release sorts after every earlier release and before the
+    release it anticipates: 1.2.3 < 1.2.4.dev0 < 1.2.4. That single ordering
+    is what makes the development suffix safe to ship in a version string:
+    every installer, resolver and `>=` floor already reads it this way.
+    """
+    development = DEVELOPMENT_VERSION.match(version)
+    if development is not None:
+        major, minor, patch = (int(part) for part in development.group("release").split("."))
+        return (major, minor, patch, 0, int(development.group("serial")))
+    major, minor, patch = (int(part) for part in version.split("."))
+    return (major, minor, patch, 1, 0)
+
+
+def is_newer(version: str, other: str) -> bool:
+    return _ordering_key(version) > _ordering_key(other)
+
+
+def next_development_version(release: str) -> str:
+    """What the first commit after `release` moves the distribution version to."""
+    major, minor, patch = (int(part) for part in release.split("."))
+    return f"{major}.{minor}.{patch + 1}.dev0"
 
 
 def _init_version(root: Path) -> str:
@@ -233,6 +298,21 @@ def _changelog_release(root: Path) -> str:
     return match.group(1)
 
 
+def release_version(root: Path) -> str:
+    """The released version every user-facing position states.
+
+    On a release commit that is the distribution version itself, and nothing
+    below can tell this tree from the one that shipped. On a tree that has moved
+    on it is the newest CHANGELOG heading: the release a reader can still
+    install, which every floor, pin, manifest and eval matrix keeps naming
+    because they describe what an install gets and not what this tree builds.
+    """
+    version = package_version(root)
+    if not is_development(version):
+        return version
+    return _changelog_release(root)
+
+
 def _json_document(root: Path, relative: str) -> dict:
     return json.loads(_read(root, relative))
 
@@ -251,8 +331,18 @@ def locations(root: Path) -> list[Location]:
     full_matrix = _json_document(root, "evals/install/matrix.full.json")
 
     return [
-        Location("pyproject.toml", "[project] version: the distribution version", (package_version(root),)),
-        Location("src/agentic_hil/__init__.py", "__version__: what the CLI and MCP server report", (_init_version(root),)),
+        Location(
+            "pyproject.toml",
+            "[project] version: the distribution version",
+            (package_version(root),),
+            tracks=DISTRIBUTION,
+        ),
+        Location(
+            "src/agentic_hil/__init__.py",
+            "__version__: what the CLI and MCP server report",
+            (_init_version(root),),
+            tracks=DISTRIBUTION,
+        ),
         Location(
             "server.json",
             "version and packages[0].version: the MCP Registry entry",
@@ -316,20 +406,43 @@ def locations(root: Path) -> list[Location]:
 
 
 def version_problems(root: Path, release_tag: str | None = None) -> list[str]:
-    """Every version source that disagrees with pyproject.toml."""
-    version = package_version(root)
+    """Every version source that disagrees with the version it is supposed to state.
+
+    Two comparisons where there used to be one, against the same list: a
+    distribution position is held to what this tree builds, a release position
+    to the release it describes. On a tree without a development suffix those
+    are one string and this is the check it always was.
+    """
+    distribution = package_version(root)
+    release = release_version(root)
     found = []
+    if is_development(distribution) and not is_newer(distribution, release):
+        found.append(
+            f"CHANGELOG.md names {release} as the newest release, but pyproject.toml states development version "
+            f"{distribution}, which does not follow it"
+        )
     for location in locations(root):
+        expected = distribution if location.tracks == DISTRIBUTION else release
         if not location.versions:
             found.append(f"{location.path} carries no version, but {location.carries} was expected")
             continue
+        subject = "this tree builds" if location.tracks == DISTRIBUTION else "this release is"
         for stated in location.versions:
-            if stated != version:
-                found.append(f"{location.path} states {stated}, but this release is {version} ({location.carries})")
+            if stated != expected:
+                found.append(f"{location.path} states {stated}, but {subject} {expected} ({location.carries})")
     if release_tag:
         tagged = release_tag[1:] if release_tag.startswith("v") else release_tag
-        if tagged != version:
-            found.append(f"release tag {release_tag} does not match pyproject.toml {version}")
+        if is_development(distribution):
+            # A tag is cut from a release commit, and a release commit is the one
+            # that sets the final number. A development version reaching this
+            # path means the release was cut from a tree that never stopped
+            # being between releases.
+            found.append(
+                f"release tag {release_tag} cannot be cut from a development tree: "
+                f"pyproject.toml states {distribution}, and a tag never carries a development suffix"
+            )
+        elif tagged != distribution:
+            found.append(f"release tag {release_tag} does not match pyproject.toml {distribution}")
     return found
 
 
@@ -365,8 +478,8 @@ def uncovered_files(root: Path, version: str | None = None) -> list[str]:
     home for the version without adding it here turns the build red, and the
     message says where.
     """
-    version = version or package_version(root)
-    carries = re.compile(rf"(?<![\w.])v?{re.escape(version)}(?![\w.])")
+    swept = (version,) if version else tuple(dict.fromkeys((release_version(root), package_version(root))))
+    carries = [(one, re.compile(rf"(?<![\w.])v?{re.escape(one)}(?![\w.])")) for one in swept]
     covered = {location.path for location in locations(root)}
     found = []
     for path in _swept_files(root):
@@ -377,12 +490,14 @@ def uncovered_files(root: Path, version: str | None = None) -> list[str]:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if carries.search(text):
-            found.append(
-                f"{relative} carries version {version} but no check covers it: "
-                f"add it to locations() in tools/check_version_consistency.py, "
-                f"or to UNTRACKED_MENTIONS with the reason it must not track the release"
-            )
+        for one, pattern in carries:
+            if pattern.search(text):
+                found.append(
+                    f"{relative} carries version {one} but no check covers it: "
+                    f"add it to locations() in tools/check_version_consistency.py, "
+                    f"or to UNTRACKED_MENTIONS with the reason it must not track the release"
+                )
+                break
     return found
 
 
@@ -424,8 +539,12 @@ def contract_problems(root: Path) -> list[str]:
     A version that agrees with itself is not enough: these documents are read by
     registries and plugin hosts, and a field that silently changes shape is a
     published mistake nobody can withdraw.
+
+    Every version here is the release: a registry entry, a marketplace listing
+    and an install command a reader copies all describe the release they can
+    install, never the tree that is being worked on.
     """
-    version = package_version(root)
+    version = release_version(root)
     found = []
 
     if (root / "plugins/agentic-hil/.mcp.json").exists():
@@ -511,27 +630,128 @@ def contract_problems(root: Path) -> list[str]:
     return found
 
 
+def _git(root: Path, arguments: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Ask git, or answer that git could not be asked."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _package_moved_since(root: Path, tag: str) -> bool | None:
+    """Whether `src/agentic_hil` differs from what `tag` shipped. None: cannot say.
+
+    `git diff` rather than a digest, so the answer comes through the line-ending
+    normalisation `.gitattributes` pins; a raw comparison of an archive against a
+    checkout reports every file as changed on a machine with core.autocrlf=true.
+    A new file nothing has added yet is invisible to `git diff`, so it is asked
+    for separately.
+    """
+    changed = _git(root, ["diff", "--quiet", tag, "--", PACKAGE])
+    if changed is None or changed.returncode not in (0, 1):
+        return None
+    if changed.returncode == 1:
+        return True
+    untracked = _git(root, ["ls-files", "--others", "--exclude-standard", "--", PACKAGE])
+    if untracked is None or untracked.returncode != 0:
+        return None
+    return bool(untracked.stdout.strip())
+
+
+def moved_tree_findings(root: Path) -> tuple[list[str], list[str]]:
+    """Refuse a tree that has moved past its release and does not say so.
+
+    This is the other half of the two-version world, and the one that keeps it
+    from being optional. A tree whose package has moved while its version stands
+    still is indistinguishable from the release it shadows: an install from it
+    reports the released number, `agentic-hil upgrade` calls it `already_current`,
+    and the install eval refuses to run a local matrix at all. The remedy is the
+    development suffix, so where the suffix is absent and the package has moved,
+    this says so.
+
+    Problems and warnings, because the question needs the release tag and not
+    every checkout has one. A fork, a shallow clone and an unpacked sdist get the
+    warning: an answer nothing here can give must not become a red build for
+    people who did nothing wrong. Everything else in this module reads files;
+    only this asks git, and a git that cannot answer is treated as an absent tag.
+    """
+    version = package_version(root)
+    if is_development(version):
+        return [], []
+    tag = f"v{_changelog_release(root)}"
+    top = _git(root, ["rev-parse", "--show-toplevel"])
+    unchecked = [
+        f"{tag} is not reachable here, so nothing checked whether {PACKAGE} still holds what that release "
+        f"shipped; a tree that has moved past its release must carry a development version"
+    ]
+    if top is None or top.returncode != 0 or not top.stdout.strip():
+        return [], unchecked
+    # The top of a checkout, or the pathspec below is resolved against a
+    # repository this tree merely sits inside, where it matches nothing and a
+    # moved package would read as an unmoved one. samefile rather than a string
+    # comparison: git answers with its own spelling of the path.
+    try:
+        inside = Path(top.stdout.strip()).samefile(root)
+    except OSError:
+        inside = False
+    if not inside:
+        return [], unchecked
+    found = _git(root, ["rev-parse", "--verify", "--quiet", f"{tag}^{{commit}}"])
+    if found is None or found.returncode != 0 or not found.stdout.strip():
+        return [], unchecked
+    moved = _package_moved_since(root, tag)
+    if moved is None:
+        return [], unchecked
+    if not moved:
+        return [], []
+    return [
+        f"{PACKAGE} has moved since {tag} while the distribution version is still {version}, so this tree "
+        f"shadows a published release: an install from it reports {version}, and nothing downstream can tell "
+        f"the two apart. Move pyproject.toml and src/agentic_hil/__init__.py to a development version such as "
+        f"{next_development_version(version)}; every other position keeps stating {version}"
+    ], []
+
+
 def problems(root: Path, release_tag: str | None = None) -> list[str]:
     return [
         *version_problems(root, release_tag),
         *uncovered_files(root),
         *unclaimed_pins(root),
         *contract_problems(root),
+        *moved_tree_findings(root)[0],
     ]
+
+
+def warnings(root: Path) -> list[str]:
+    """What the gate could not establish here, as opposed to what it refuses."""
+    return moved_tree_findings(root)[1]
 
 
 def render_list(root: Path) -> str:
     """The checklist, printed from the check that enforces it."""
-    version = package_version(root)
+    distribution = package_version(root)
+    release = release_version(root)
     carried = locations(root)
     occurrences = sum(len(location.versions) for location in carried)
     # Distinct paths, not entries: a file may hold several claims — TROUBLESHOOTING.md
     # carries requirement pins and a git-tag pin as two entries.
     files = len({location.path for location in carried})
-    lines = [f"Release version {version} is carried in {files} files, {occurrences} occurrences:", ""]
+    built = f", built as {distribution}" if distribution != release else ""
+    lines = [f"Release version {release}{built} is carried in {files} files, {occurrences} occurrences:", ""]
     for location in carried:
         count = len(location.versions)
-        suffix = "" if count == 1 else f"  [{count} occurrences]"
+        marks = []
+        if count != 1:
+            marks.append(f"{count} occurrences")
+        if location.tracks == DISTRIBUTION:
+            marks.append("the distribution version")
+        suffix = f"  [{', '.join(marks)}]" if marks else ""
         lines.append(f"  {location.path}{suffix}")
         lines.append(f"      {location.carries}")
     lines.append("")
@@ -563,6 +783,8 @@ def main(argv: list[str] | None = None) -> int:
         print(render_list(root))
         return 0
     found = problems(root, release_tag)
+    for note in warnings(root):
+        print(f"WARNING: {note}", file=sys.stderr)
     for problem in found:
         print(problem, file=sys.stderr)
     return 1 if found else 0


### PR DESCRIPTION
Fixes #214. First commit of the 0.13.x cycle: the tree moves to `0.13.1.dev0` and the gates learn the two-version world.

## What changed

- Only `pyproject.toml` and `src/agentic_hil/__init__.py` follow the tree (the two positions that identify the built artifact, encoded as `Location.tracks` in the gate, pinned by test). Every floor, install pin, published manifest and eval matrix keeps naming the release a reader can install (0.13.0).
- The version gate holds both shapes: a release-shaped tree behaves exactly as today; a dev tree must extend the newest CHANGELOG heading; `--release-tag` refuses a dev suffix outright; and off-tag, a tree whose `src/agentic_hil` moved past its release WITHOUT a suffix is refused wherever the release tag exists to prove it (warning in forks/shallow clones). The pre-merge CI job fetches full history so the tag is there, with a test pinning the fetch so it cannot become decorative.
- `check_shipped_references.py` asks the gate for the release version instead of answering the question a second time.
- The install eval expects the version an install actually produces: the tree's own (dev suffix and all) for local and remote runs, the release for published; `target.expected_version` keeps naming the release, and the moved-tree refusal from #215 is skipped exactly when the suffix says nothing is being reported as the release.
- `docs/release-strategy.md` writes the cycle down.

## Verification

Windows 1915 passed / 42 skipped, container 1919 passed / 38 skipped, ruff clean, both gates green ON the dev tree (which is the point), `python -m build` + twine on `0.13.1.dev0` pass. 12 targeted teeth reverts, all bite. PEP 440 ordering pinned (`1.2.4.dev0 > 1.2.3`, `< 1.2.4`). Author audit clean.