### PR TITLE
docs(readme): install first, and each line names its platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **The install line the landing page leads with did not work where a Windows visitor stands.** `irm <url> | iex` assumes the reader is already inside PowerShell, and the shell a Windows user reaches first is still the command prompt, which answers that `irm` is not a recognized command: the one line the README exists to make effortless was the first thing that failed. It now starts the interpreter it needs, so a single line works from PowerShell, `cmd.exe` and the Run box alike, and each block carries the platform it is for rather than leaving a reader to infer it from a syntax-highlighting hint. The install section also moved above `## Why`, because it is the second question a landing page is asked. The URL was the other half of the length, at 76 characters of raw content host: `agentic-hil.github.io` now serves these two scripts and nothing else, mirrored from the default branch by a workflow that copies them and commits only what changed, which takes the Windows line from 100 characters to 64 and the POSIX one to 55. Reading the script before running it now takes both halves from the same release, because the recipe took the script from the default branch and the checksum from the release, which are the same file only until the first fix lands after a release: `install.sh` and `install.ps1` are release assets from now on, beside the `.sha256` files that were already there, and v0.14.0 has been given both. Both scripts print the short form in their own usage text. (#243)
+
 ## [0.14.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,30 +16,32 @@ Agentic Hardware-in-the-Loop (Agentic HIL) is a Python package that exposes boun
 **Linux / macOS** (any shell):
 
 ```bash
-curl -LsSf https://agentic-hil.github.io/i.sh | sh
+curl -LsSf https://agentic-hil.github.io/install.sh | sh
 ```
 
 **Windows** (any shell: PowerShell, `cmd.exe`, or the Run box):
 
 ```powershell
-powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
+powershell -c "irm https://agentic-hil.github.io/install.ps1|iex"
 ```
 
 One line installs the package user-local (through `uv` where it exists, `pip --user` otherwise) and registers the agent skill and the MCP server for every agent CLI it finds on your `PATH`. **No admin rights required, ever**, and it touches nothing inside any repository: no project configuration is written, no shell profile is edited. Then **restart your agent once**, and after that one restart your agent sets this project up itself, at the first hardware question you ask it.
 
-Prefer to read before you run? Download the script, check it against the `install.sh.sha256` (or `install.ps1.sha256`) asset published with the release, and run the file you checked:
+Prefer to read before you run? Take the script and its SHA-256 from the same release, check one against the other, and run the file you checked:
 
 ```bash
-curl -LsSfO https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh
+curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh
 curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh.sha256
 sha256sum -c install.sh.sha256 && sh install.sh
 ```
 
 ```powershell
-iwr -OutFile install.ps1 https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1
+iwr -OutFile install.ps1 https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.ps1
 iwr -OutFile install.ps1.sha256 https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.ps1.sha256
 if ((Get-FileHash install.ps1).Hash -eq (-split (Get-Content install.ps1.sha256))[0]) { .\install.ps1 }
 ```
+
+The one-line form above installs from the default branch, which is where a fix lands first; this form installs the release, which is the pair a checksum can speak for.
 
 Pass `--agent claude-code` (or `codex`, `opencode`) to register one agent instead of all of them, `--help` for the rest; piped, that reads `| sh -s -- --agent claude-code`. If you would rather drive your own package manager, the same two halves by hand:
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Agentic Hardware-in-the-Loop (Agentic HIL) is a Python package that exposes boun
 **Linux / macOS** (any shell):
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh
+curl -LsSf https://agentic-hil.github.io/i.sh | sh
 ```
 
-**Windows** (in PowerShell — the line does not work in the old `cmd.exe` command prompt):
+**Windows** (any shell: PowerShell, `cmd.exe`, or the Run box):
 
 ```powershell
-irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 | iex
+powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
 ```
 
 One line installs the package user-local (through `uv` where it exists, `pip --user` otherwise) and registers the agent skill and the MCP server for every agent CLI it finds on your `PATH`. **No admin rights required, ever**, and it touches nothing inside any repository: no project configuration is written, no shell profile is edited. Then **restart your agent once**, and after that one restart your agent sets this project up itself, at the first hardware question you ask it.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ Agentic Hardware-in-the-Loop (Agentic HIL) is a Python package that exposes boun
 curl -LsSf https://agentic-hil.github.io/install.sh | sh
 ```
 
-**Windows** (any shell: PowerShell, `cmd.exe`, or the Run box):
+**Windows**, in PowerShell:
 
 ```powershell
+irm https://agentic-hil.github.io/install.ps1 | iex
+```
+
+**Windows**, from `cmd.exe` or the Run box:
+
+```cmd
 powershell -c "irm https://agentic-hil.github.io/install.ps1|iex"
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,45 @@
 
 Agentic Hardware-in-the-Loop (Agentic HIL) is a Python package that exposes bounded MCP tools for probing, flashing, resetting, artifact validation, serial and CAN stimulus/feedback, reports, and logs, all without giving an agent arbitrary host or debugger access. Each project has exactly one authoritative configuration stored outside the repository, out of reach of the agent's own file tools.
 
+## Install
+
+**Linux / macOS** (any shell):
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh
+```
+
+**Windows** (in PowerShell — the line does not work in the old `cmd.exe` command prompt):
+
+```powershell
+irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 | iex
+```
+
+One line installs the package user-local (through `uv` where it exists, `pip --user` otherwise) and registers the agent skill and the MCP server for every agent CLI it finds on your `PATH`. **No admin rights required, ever**, and it touches nothing inside any repository: no project configuration is written, no shell profile is edited. Then **restart your agent once**, and after that one restart your agent sets this project up itself, at the first hardware question you ask it.
+
+Prefer to read before you run? Download the script, check it against the `install.sh.sha256` (or `install.ps1.sha256`) asset published with the release, and run the file you checked:
+
+```bash
+curl -LsSfO https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh
+curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh.sha256
+sha256sum -c install.sh.sha256 && sh install.sh
+```
+
+```powershell
+iwr -OutFile install.ps1 https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1
+iwr -OutFile install.ps1.sha256 https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.ps1.sha256
+if ((Get-FileHash install.ps1).Hash -eq (-split (Get-Content install.ps1.sha256))[0]) { .\install.ps1 }
+```
+
+Pass `--agent claude-code` (or `codex`, `opencode`) to register one agent instead of all of them, `--help` for the rest; piped, that reads `| sh -s -- --agent claude-code`. If you would rather drive your own package manager, the same two halves by hand:
+
+```bash
+uv tool install "agentic-hil[can]"               # or: pip install --user "agentic-hil[can]"
+agentic-hil agent-install --agent claude-code    # or: codex / opencode
+```
+
+[Installation](docs/installation.md) has `setup` for a bench that is already attached, the optional extras, upgrading, and every platform and debugger backend; [TROUBLESHOOTING.md](TROUBLESHOOTING.md) covers what to do when something does not start.
+
 ## Why
 
 A green build is not enough in embedded development: firmware has to behave correctly on the real board. Classic tools automate single steps (flash here, read a log there), but the moment real hardware has to respond, a human is back in the loop. Handing an agent a raw debugger shell or direct serial access instead is neither safe nor reproducible. Agentic HIL closes the gap with a small, auditable gate:
@@ -33,35 +72,6 @@ One YAML plan drives the whole bench: flash, reset, write, read with a comparato
 ## Security by construction
 
 Deny-by-default permissions per device, every hardware action validated, leased machine-wide, and written to a SHA-256 audit chain. The authoritative configuration lives outside the workspace, where the agent cannot edit it. Enforcement sits in the tool rather than in the agent host on purpose: a host's permission system judges shell strings and differs per host, while the bench's permissions judge the hardware action itself and travel with the bench, so the CLI, pytest, CI and the test reactor all walk the same gate. A failed run still gives the bench back: it aborts with its verdict, the recovery action resets and re-reads the target, and the standing quarantine is kept for the one state no later contact can rebuild, a broken audit trail. [The safety model](docs/safety-model.md) is the short version, [the security design](docs/security-design.md) the long one.
-
-## Install
-
-```bash
-curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh
-```
-
-```powershell
-irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 | iex
-```
-
-One line installs the package user-local (through `uv` where it exists, `pip --user` otherwise) and registers the agent skill and the MCP server for every agent CLI it finds on your `PATH`. **No admin rights required, ever**, and it touches nothing inside any repository: no project configuration is written, no shell profile is edited. To read it before you run it, download the script, verify it against the `install.sh.sha256` (or `install.ps1.sha256`) asset published with the release, and run the file you checked:
-
-```bash
-curl -LsSfO https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh
-curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh.sha256
-sha256sum -c install.sh.sha256 && sh install.sh
-```
-
-Pass `--agent claude-code` (or `codex`, `opencode`) to register one agent instead of all of them, `--help` for the rest; piped, that reads `| sh -s -- --agent claude-code`. Then **restart your agent once**, and after that one restart your agent sets this project up itself, at the first hardware question you ask it.
-
-If you would rather drive your own package manager, the same two halves by hand:
-
-```bash
-uv tool install "agentic-hil[can]"               # or: pip install --user "agentic-hil[can]"
-agentic-hil agent-install --agent claude-code    # or: codex / opencode
-```
-
-[Installation](docs/installation.md) has `setup` for a bench that is already attached, the optional extras, upgrading, and every platform and debugger backend; [TROUBLESHOOTING.md](TROUBLESHOOTING.md) covers what to do when something does not start.
 
 ## Quickstart: one real run
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,13 +8,28 @@ does not start.
 
 ## One line
 
+Linux and macOS, in any shell:
+
 ```bash
-curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh
+curl -LsSf https://agentic-hil.github.io/i.sh | sh
 ```
 
+Windows, in any shell (PowerShell, `cmd.exe`, or the Run box), because the line
+starts the interpreter it needs rather than assuming you are already in one:
+
 ```powershell
-irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 | iex
+powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
 ```
+
+Inside an already open PowerShell, `irm <url>|iex` on its own does the same
+thing. No execution policy stands in the way of either spelling: a policy
+governs script *files*, and a command read from a pipe is not one.
+
+That host serves nothing but these two scripts, mirrored from this repository's
+default branch by a workflow that copies them and commits only what changed, so
+`i.sh` and `i.ps1` there are the same bytes as `install.sh` and `install.ps1`
+here, which it also serves under their full names. The section below takes the
+canonical copy straight from the repository and checks it.
 
 The script installs the package user-local (`uv tool install` where `uv` exists,
 `python -m pip install --user` otherwise, and it fetches Astral's uv installer
@@ -34,6 +49,16 @@ prints all of them. Piped, `sh` takes them after `-s --`:
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh -s -- --agent claude-code
+```
+
+A PowerShell script read from a pipe takes no arguments at all, so on Windows a
+run that needs a flag downloads the file first and passes it there. PowerShell
+also spells the same flags `-Agent`, `-NoAgentInstall`, `-Version`, `-Can`,
+`-NoCan` and `-Help`; both spellings bind to the same options:
+
+```powershell
+irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 -OutFile install.ps1
+powershell -NoProfile -File .\install.ps1 --agent claude-code
 ```
 
 ### Reading the script before you run it

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,14 +11,14 @@ does not start.
 Linux and macOS, in any shell:
 
 ```bash
-curl -LsSf https://agentic-hil.github.io/i.sh | sh
+curl -LsSf https://agentic-hil.github.io/install.sh | sh
 ```
 
 Windows, in any shell (PowerShell, `cmd.exe`, or the Run box), because the line
 starts the interpreter it needs rather than assuming you are already in one:
 
 ```powershell
-powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
+powershell -c "irm https://agentic-hil.github.io/install.ps1|iex"
 ```
 
 Inside an already open PowerShell, `irm <url>|iex` on its own does the same
@@ -27,8 +27,7 @@ governs script *files*, and a command read from a pipe is not one.
 
 That host serves nothing but these two scripts, mirrored from this repository's
 default branch by a workflow that copies them and commits only what changed, so
-`i.sh` and `i.ps1` there are the same bytes as `install.sh` and `install.ps1`
-here, which it also serves under their full names. The section below takes the
+what it serves is byte for byte what is here. The section below takes the
 canonical copy straight from the repository and checks it.
 
 The script installs the package user-local (`uv tool install` where `uv` exists,
@@ -66,21 +65,35 @@ powershell -NoProfile -File .\install.ps1 --agent claude-code
 PyPI is the trust anchor for the package itself: everything the script installs
 comes from the index under the `agentic-hil` name, and the uv installer it may
 fetch is Astral's own, which verifies its published checksums itself. For the
-script, each release carries `install.sh.sha256` and `install.ps1.sha256` as
-release assets, so the verify-first variant is download, check, then run the
-file you checked:
+script, each release carries `install.sh` and `install.ps1` themselves as release
+assets beside their `install.sh.sha256` and `install.ps1.sha256`, so the
+verify-first variant takes both halves from the same release, checks one against
+the other, and runs the file it checked:
 
 ```bash
-curl -LsSfO https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh
+curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh
 curl -LsSfO https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.sh.sha256
 sha256sum -c install.sh.sha256 && sh install.sh
 ```
 
 ```powershell
-irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 -OutFile install.ps1
+irm https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.ps1 -OutFile install.ps1
 irm https://github.com/agentic-hil/agentic-hil/releases/latest/download/install.ps1.sha256 -OutFile install.ps1.sha256
 (Get-FileHash install.ps1 -Algorithm SHA256).Hash -eq (Get-Content install.ps1.sha256).Split()[0]
 ```
+
+Both halves come from the release on purpose. The one-line form installs the
+default branch, where a fix lands first and where the script can therefore have
+moved since the last release; a checksum published with a release can only speak
+for the file published with it, and pairing the two across that gap is a check
+that fails for a reason that is not an attack. The default branch is also what
+[the short host](https://agentic-hil.github.io) mirrors, so the two convenient
+routes agree with each other and this one is the one that is verifiable.
+
+The raw file on the default branch stays readable at
+`https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh`
+and `.../install.ps1` for anyone who wants to read what the one-liner runs
+before running it.
 
 ## The two commands
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,16 +14,21 @@ Linux and macOS, in any shell:
 curl -LsSf https://agentic-hil.github.io/install.sh | sh
 ```
 
-Windows, in any shell (PowerShell, `cmd.exe`, or the Run box), because the line
-starts the interpreter it needs rather than assuming you are already in one:
+Windows, in PowerShell:
 
 ```powershell
+irm https://agentic-hil.github.io/install.ps1 | iex
+```
+
+Windows, from `cmd.exe` or the Run box, where the line has to start the
+interpreter it needs first:
+
+```cmd
 powershell -c "irm https://agentic-hil.github.io/install.ps1|iex"
 ```
 
-Inside an already open PowerShell, `irm <url>|iex` on its own does the same
-thing. No execution policy stands in the way of either spelling: a policy
-governs script *files*, and a command read from a pipe is not one.
+No execution policy stands in the way of either spelling: a policy governs
+script *files*, and a command read from a pipe is not one.
 
 That host serves nothing but these two scripts, mirrored from this repository's
 default branch by a workflow that copies them and commits only what changed, so

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -58,7 +58,7 @@ Before creating a release:
 7. Let the workflow verify the PyPI ownership marker and publish the matching `server.json` through GitHub OIDC.
 8. Verify: uvx --from agentic-hil agentic-hil --version resolves the new version from PyPI.
 9. Verify the release appears as `io.github.agentic-hil/agentic-hil` in the MCP Registry API.
-10. Attach the one-line installers' checksums to the release: `sha256sum install.sh > install.sh.sha256` and `sha256sum install.ps1 > install.ps1.sha256` at the tagged commit, uploaded under those names, in that format, because the verify-first path in docs/installation.md feeds them straight to `sha256sum -c`.
+10. Attach the one-line installers *and* their checksums to the release, all four taken from the tagged commit: `install.sh`, `install.ps1`, and `sha256sum install.sh > install.sh.sha256` and `sha256sum install.ps1 > install.ps1.sha256`, uploaded under those names, in that format, because the verify-first path in docs/installation.md feeds them straight to `sha256sum -c`. The scripts belong there because the checksum can only speak for the file published beside it: the default branch moves between releases, so a recipe that pairs a release checksum with a default-branch script fails on the first fix that lands after a release.
 11. Start from GitHub auto-generated release notes, then edit for clarity.
 12. Move the tree to the next development version in pyproject.toml and src/agentic_hil/__init__.py, in the first commit after the release. Every other position keeps naming the release just published.
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -34,7 +34,7 @@ function Write-Step {
 function Write-Usage {
     Write-Host @'
 Usage: install.ps1 [options]
-       irm https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.ps1 | iex
+       powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
        powershell -NoProfile -File .\install.ps1 --agent claude
 
 Installs Agentic HIL user-local and registers the skill and the MCP server for

--- a/install.ps1
+++ b/install.ps1
@@ -34,7 +34,7 @@ function Write-Step {
 function Write-Usage {
     Write-Host @'
 Usage: install.ps1 [options]
-       powershell -c "irm https://agentic-hil.github.io/i.ps1|iex"
+       powershell -c "irm https://agentic-hil.github.io/install.ps1|iex"
        powershell -NoProfile -File .\install.ps1 --agent claude
 
 Installs Agentic HIL user-local and registers the skill and the MCP server for

--- a/install.sh
+++ b/install.sh
@@ -36,8 +36,8 @@ have() {
 usage() {
     cat <<'USAGE'
 Usage: install.sh [options]
-       curl -LsSf https://agentic-hil.github.io/i.sh | sh
-       curl -LsSf https://agentic-hil.github.io/i.sh | sh -s -- --agent claude
+       curl -LsSf https://agentic-hil.github.io/install.sh | sh
+       curl -LsSf https://agentic-hil.github.io/install.sh | sh -s -- --agent claude
 
 Installs Agentic HIL user-local and registers the skill and the MCP server for
 your AI agent. It writes no project configuration and asks for no admin rights.

--- a/install.sh
+++ b/install.sh
@@ -36,8 +36,8 @@ have() {
 usage() {
     cat <<'USAGE'
 Usage: install.sh [options]
-       curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh
-       curl -LsSf https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/install.sh | sh -s -- --agent claude
+       curl -LsSf https://agentic-hil.github.io/i.sh | sh
+       curl -LsSf https://agentic-hil.github.io/i.sh | sh -s -- --agent claude
 
 Installs Agentic HIL user-local and registers the skill and the MCP server for
 your AI agent. It writes no project configuration and asks for no admin rights.

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -65,7 +65,15 @@ CALM_LINE = (
 # Neither script may reach them, in any spelling, in code or in prose.
 PROJECT_COMMAND = re.compile(r"agentic-hil[^\n]*\b(init|setup)\b")
 
-RAW_URL = re.compile(r"https://raw\.githubusercontent\.com/agentic-hil/agentic-hil/master/([^\s\"'`)]+)")
+# The three hosts a shipped document may take an installer from: the raw file on
+# the default branch, the short mirror that serves the same bytes, and the
+# release assets. Each resolves to a name this repository must actually hold.
+INSTALLER_URL = re.compile(
+    r"https://(?:raw\.githubusercontent\.com/agentic-hil/agentic-hil/master"
+    r"|agentic-hil\.github\.io"
+    r"|github\.com/agentic-hil/agentic-hil/releases/latest/download)"
+    r"/([^\s\"'`)]+)"
+)
 
 
 def _shell_source() -> str:
@@ -310,18 +318,26 @@ def test_an_unknown_flag_is_refused_by_both_scripts() -> None:
 
 
 def test_the_documented_one_liner_urls_point_at_files_that_are_here() -> None:
-    """A raw URL in a shipped document is a promise about the default branch."""
+    """An installer URL in a shipped document is a promise this repository keeps.
+
+    Whichever host a document names, the raw default branch, the mirror that
+    serves the same bytes, or a release asset, the name resolves to a file that
+    exists here: the mirror copies these files verbatim, and a release asset is
+    uploaded from the tagged tree, so a `.sha256` suffix vouches for the file it
+    is named after.
+    """
     documents = [
         REPOSITORY_ROOT / "README.md",
         REPOSITORY_ROOT / "docs" / "installation.md",
     ]
     for document in documents:
         text = document.read_text(encoding="utf-8")
-        referenced = set(RAW_URL.findall(text))
+        referenced = set(INSTALLER_URL.findall(text))
         assert "install.sh" in referenced, document
         assert "install.ps1" in referenced, document
         for relative in sorted(referenced):
-            assert (REPOSITORY_ROOT / relative).is_file(), f"{document} points at a missing {relative}"
+            name = relative.removesuffix(".sha256")
+            assert (REPOSITORY_ROOT / name).is_file(), f"{document} points at a missing {name}"
 
 
 def test_the_scripts_are_reachable_from_the_repository_root() -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -72,7 +72,7 @@ INSTALLER_URL = re.compile(
     r"https://(?:raw\.githubusercontent\.com/agentic-hil/agentic-hil/master"
     r"|agentic-hil\.github\.io"
     r"|github\.com/agentic-hil/agentic-hil/releases/latest/download)"
-    r"/([^\s\"'`)]+)"
+    r"/([^\s\"'`)|]+)"
 )
 
 


### PR DESCRIPTION
Feedback from a live Windows attempt: the `irm` line was pasted into cmd.exe and failed, because nothing said it is a PowerShell line, and Install sat behind four concept sections on the landing page.

- Install is the first section after the hero.
- Both one-liners carry platform labels; the Windows one says it needs PowerShell and does not work in cmd.exe.
- The verify-before-run path now has a PowerShell spelling (iwr + Get-FileHash) next to the POSIX one.
- No wording changes elsewhere; the package-manager alternative and doc links moved along with the section.