### PR TITLE
chore(version): the cycle carries two versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.16.0"
+version = "0.16.1.dev0"
 description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.16.0"
+__version__ = "0.16.1.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager


### PR DESCRIPTION
Moves the two artifact-identifying positions to 0.16.1.dev0 now that v0.16.0 is tagged, per the #214 discipline. Every floor, pin, manifest and matrix keeps naming 0.16.0.