### PR TITLE
fix(install): compare against the release, not a capability floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Fixed
+
+- **The one-line installer kept whatever agentic-hil it found and told a returning user each step was done.** Step 1 compared an installation already on `PATH` against a floor of `0.4.0`, the release that first shipped `agent-install`, and skipped the package install for anything at or above it. That answers whether the copy can run step 4, not whether it is the copy the person typing the line asked for, and the same line is what README hands a stranger and what a returning user re-runs to get current. The cost was not only an old package: step 4 installs the skill out of the copy step 1 decided to keep, so a bench on 0.11.0 was left on 0.11.0 and written a 0.11.0 skill, five releases behind, with every step reported as done. Both scripts now compare against the release they install, so an older copy goes through the upgrade step 2 already performs and a copy at or above the release is kept as before; a development tree reports `X.Y.Z.devN`, which the existing comparison reads as `X.Y.Z`, so an editable install is still left alone. The number is a release position now rather than a constant two people have to remember: `tools/check_version_consistency.py` carries an entry for each script and fails the build when either falls behind. (#291)
+
 ## [0.16.0] - 2026-08-18
 
 ### Added

--- a/install.ps1
+++ b/install.ps1
@@ -18,7 +18,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$Floor = '0.4.0'
+# The release this script installs, and the version an installation already
+# here has to reach to be left alone. Deliberately not a capability floor: the
+# line that installs Agentic HIL is the same line people re-run to get current,
+# and step 4 registers the skill out of whatever copy step 1 decided to keep, so
+# a floor left a returning user on an old package and an old skill at once. A
+# development tree reports X.Y.Z.devN, which compares as X.Y.Z and stays put.
+$Release = '0.16.0'
 $StepTotal = 5
 
 function Write-Say {
@@ -177,12 +183,12 @@ function Test-VersionExactly {
 function Test-VersionMatchesRequest {
     param([string]$Found)
     # Does a freshly installed copy's reported version answer what this run asked
-    # for: exactly the pin when one was given, at least the floor otherwise. The
+    # for: exactly the pin when one was given, at least the release otherwise. The
     # pin must match exactly -- a newer copy left in the manager's bin is not the
     # pinned release this run wrote, and the documented --version contract is an
     # exact release, not a floor.
     if ($Version) { return (Test-VersionExactly -Found $Found -Wanted $Version) }
-    return (Test-VersionAtLeast -Found $Found -Floor $Floor)
+    return (Test-VersionAtLeast -Found $Found -Floor $Release)
 }
 
 function Get-UvBinDirectory {
@@ -317,11 +323,11 @@ if (Test-Executable 'agentic-hil') {
         Write-Step 1 'probe: an agentic-hil on this PATH does not answer, installing it again'
     } elseif ($Version) {
         Write-Step 1 "probe: agentic-hil $installed is here, and --version $Version was asked for, so the package is installed again"
-    } elseif (Test-VersionAtLeast -Found $installed -Floor $Floor) {
-        Write-Step 1 "probe: agentic-hil $installed is here and at least $Floor, skipping the package install"
+    } elseif (Test-VersionAtLeast -Found $installed -Floor $Release) {
+        Write-Step 1 "probe: agentic-hil $installed is here and not older than $Release, skipping the package install"
         $needsPackage = $false
     } else {
-        Write-Step 1 "probe: agentic-hil $installed is older than $Floor, upgrading it"
+        Write-Step 1 "probe: agentic-hil $installed is older than $Release, upgrading it"
     }
 } else {
     Write-Step 1 'probe: no agentic-hil on this PATH, installing it user-local'

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,13 @@
 
 set -eu
 
-FLOOR="0.4.0"
+# The release this script installs, and the version an installation already
+# here has to reach to be left alone. Deliberately not a capability floor: the
+# line that installs Agentic HIL is the same line people re-run to get current,
+# and step 4 registers the skill out of whatever copy step 1 decided to keep, so
+# a floor left a returning user on an old package and an old skill at once. A
+# development tree reports X.Y.Z.devN, which compares as X.Y.Z and stays put.
+RELEASE="0.16.0"
 
 AGENT=""
 WITH_AGENT_INSTALL=1
@@ -198,16 +204,16 @@ package_spec() {
 }
 
 # Does a freshly installed copy's reported version answer what this run asked
-# for: exactly the pin when one was given, at least the floor otherwise. The pin
+# for: exactly the pin when one was given, at least the release otherwise. The pin
 # must match exactly -- a newer copy left in the manager's bin is not the pinned
 # release this run wrote, and the documented --version contract is an exact
 # release, not a floor. Without a pin the manager only ever writes the newest, so
-# any copy at or above the floor is the one just installed.
+# any copy at or above the release is the one just installed.
 version_matches_request() {
     if [ -n "$PINNED" ]; then
         version_exactly "$1" "$PINNED"
     else
-        version_at_least "$1" "$FLOOR"
+        version_at_least "$1" "$RELEASE"
     fi
 }
 
@@ -439,11 +445,11 @@ elif ! installed=$(agentic-hil --version 2>/dev/null); then
     step 1 "probe: an agentic-hil on this PATH does not answer, installing it again"
 elif [ -n "$PINNED" ]; then
     step 1 "probe: agentic-hil $installed is here, and --version $PINNED was asked for, so the package is installed again"
-elif version_at_least "$installed" "$FLOOR"; then
-    step 1 "probe: agentic-hil $installed is here and at least $FLOOR, skipping the package install"
+elif version_at_least "$installed" "$RELEASE"; then
+    step 1 "probe: agentic-hil $installed is here and not older than $RELEASE, skipping the package install"
     NEEDS_PACKAGE=0
 else
-    step 1 "probe: agentic-hil $installed is older than $FLOOR, upgrading it"
+    step 1 "probe: agentic-hil $installed is older than $RELEASE, upgrading it"
 fi
 
 # Step 2: install the package, user-local, never as root.

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -964,6 +964,102 @@ def test_both_scripts_require_an_exact_match_for_a_version_pin() -> None:
     assert "Test-VersionMatchesRequest" in powershell
 
 
+def test_both_scripts_install_the_same_release() -> None:
+    """The version an installation already here has to reach, stated once per script.
+
+    It is the release now, not the capability floor it used to be. Both scripts
+    have to move together for the same line to mean the same thing on either
+    platform; tools/check_version_consistency.py holds the number to the release,
+    and this holds the two scripts to each other.
+    """
+    shell = re.search(r'^RELEASE="(\d+\.\d+\.\d+)"$', _shell_source(), re.MULTILINE)
+    powershell = re.search(r"^\$Release = '(\d+\.\d+\.\d+)'$", _powershell_source(), re.MULTILINE)
+    assert shell is not None, "install.sh states no RELEASE"
+    assert powershell is not None, "install.ps1 states no $Release"
+    assert shell.group(1) == powershell.group(1)
+
+
+def test_an_installation_below_the_release_is_upgraded_rather_than_kept(tmp_path: Path) -> None:
+    """The returning user, run end to end through a POSIX shell.
+
+    Step 1 compared against a capability floor of 0.4.0, so every copy installed
+    since answered "skipping the package install" and step 4 registered the skill
+    out of that copy: the one line the README hands a stranger left a 0.11.0 bench
+    on 0.11.0 and wrote it a 0.11.0 skill, silently, while reporting success. The
+    comparison is against the release now, so an older copy is upgraded and the
+    machine half runs out of the fresh one.
+    """
+    if os.name != "posix":
+        pytest.skip("the shell install flow is exercised on the POSIX half")
+    shell = _posix_shell()
+
+    home = tmp_path / "home"
+    project = home / "project"
+    user_bin = home / ".local" / "bin"
+    uv_bin = tmp_path / "uv-tools" / "bin"
+    tools = tmp_path / "tools"
+    for directory in (project, user_bin, uv_bin, tools):
+        directory.mkdir(parents=True)
+
+    marker = tmp_path / "who-ran-agent-install"
+
+    # A real earlier release: far above the floor step 1 used to accept, far
+    # below the release it compares against now.
+    _stub_executable(
+        user_bin / "agentic-hil",
+        'case "$1" in\n'
+        '  --version) echo "0.11.0" ;;\n'
+        f'  agent-install) echo "stale" > "{marker}"; printf \'{{\\n  "ok": true\\n}}\\n\' ;;\n'
+        "esac\n"
+        "exit 0\n",
+    )
+    _stub_executable(tools / "claude", "exit 0\n")
+    _stub_executable(
+        tools / "uv",
+        'if [ "$1" = "tool" ] && [ "$2" = "dir" ]; then\n'
+        '  echo "$UV_TOOL_BIN_DIR"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "tool" ] && [ "$2" = "install" ]; then\n'
+        '  cat > "$UV_TOOL_BIN_DIR/agentic-hil" <<STUB\n'
+        "#!/bin/sh\n"
+        'case "\\$1" in\n'
+        '  --version) echo "99.0.0" ;;\n'
+        f'  agent-install) echo "fresh" > "{marker}"; printf \'{{\\n  "ok": true\\n}}\\n\' ;;\n'
+        "esac\n"
+        "exit 0\n"
+        "STUB\n"
+        '  chmod +x "$UV_TOOL_BIN_DIR/agentic-hil"\n'
+        "fi\n"
+        "exit 0\n",
+    )
+
+    env = {
+        "HOME": str(home),
+        "PATH": f"{tools}:{user_bin}:/usr/bin:/bin",
+        "UV_TOOL_BIN_DIR": str(uv_bin),
+    }
+
+    result = subprocess.run(
+        [shell, str(SHELL_SCRIPT), "--no-can"],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=SCRIPT_TIMEOUT_S,
+        check=False,
+    )
+
+    transcript = f"{result.stdout}{result.stderr}"
+    assert result.returncode == 0, transcript
+    assert "skipping the package install" not in transcript, transcript
+    assert "0.11.0 is older than" in transcript, transcript
+    assert marker.is_file(), transcript
+    assert marker.read_text(encoding="utf-8").strip() == "fresh", transcript
+
+
 # The container run, end to end: a machine with nothing on it, the real package
 # from the index, a stub `claude` on PATH so agent detection has something to
 # find, and then the four questions that decide whether the line did its job.

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -93,6 +93,14 @@ EXPECTED_VERSION_FIELD = re.compile(r"""["']expected_version["']\s*:\s*["']([^"'
 # `actions/checkout@v4` and every other third-party pin carries somebody
 # else's version and must stay invisible to this gate.
 TAG_PIN = re.compile(r"""([^\s"'`@]+)@v(\d+\.\d+\.\d+)(?![\w.])""")
+# The release each one-line installer installs, and the version an installation
+# already on the machine has to reach to be left alone. Both are a single
+# constant at the top of their script, and both have to follow the release: an
+# installer holding a number below it answers "nothing to install" to the very
+# person re-running the line to get current, and then registers the skill out of
+# the copy it kept.
+INSTALL_SH_RELEASE = re.compile(r'^RELEASE="(\d+\.\d+\.\d+)"$', re.MULTILINE)
+INSTALL_PS1_RELEASE = re.compile(r"^\$Release = '(\d+\.\d+\.\d+)'$", re.MULTILINE)
 
 # The sweep walks the working tree, so it meets whatever else lives there.
 SKIPPED_DIRECTORIES = frozenset(
@@ -436,6 +444,16 @@ def locations(root: Path) -> list[Location]:
             "evals/install/matrix.full.json",
             "target.expected_version: the install-eval runner refuses to start when it disagrees",
             (str(full_matrix["target"]["expected_version"]),),
+        ),
+        Location(
+            "install.sh",
+            "RELEASE: the release the one-line installer installs, and the version an installation already here has to reach to be kept",
+            tuple(INSTALL_SH_RELEASE.findall(_read(root, "install.sh"))),
+        ),
+        Location(
+            "install.ps1",
+            "$Release: the release the one-line installer installs, and the version an installation already here has to reach to be kept",
+            tuple(INSTALL_PS1_RELEASE.findall(_read(root, "install.ps1"))),
         ),
         Location(
             "evals/install/README.md",


### PR DESCRIPTION
Closes #291.

`install.sh` and `install.ps1` compared an agentic-hil already on `PATH` against a floor of `0.4.0`, the release that first shipped `agent-install`, and kept anything at or above it. That answers whether the copy can run step 4. It does not answer what the person typing the line is asking, and the same line is what README hands a stranger and what a returning user re-runs to get current.

Reported from a real run: a bench on 0.11.0 got `skipping the package install`, then step 4 registered the skill out of that kept copy and moved it from 0.8.0 to 0.11.0, five releases behind, with every step reported as done.

Both scripts now compare against the release they install. An older copy goes through the upgrade step 2 already performs (`uv tool install --upgrade`, `pip install --user --upgrade`); a copy at or above the release is kept exactly as before. A development tree reports `X.Y.Z.devN`, which the existing three-field comparison reads as `X.Y.Z`, so an editable install is still left alone.

The number now has to follow every release, so it is a release position rather than a constant two people have to remember: `tools/check_version_consistency.py` carries an entry for each script, and a script left behind fails the build with the file and both numbers named.

### Tested

- `ruff check src tests evals tools`
- `pytest tests/test_install_scripts.py` on Windows: 31 passed, 6 skipped
- the version gate both ways: green as committed, and red with `install.sh` set to 0.15.0 (`install.sh states 0.15.0, but this release is 0.16.0`)
- `sh -n install.sh`

Not run locally: the POSIX end-to-end test added here, and the rest of the POSIX half. The Docker daemon on the development machine is down, so `python tools/ci_linux.py` reported that nothing was tested rather than a pass. The Linux job in this PR is what proves them.
