### PR TITLE
chore(metadata): sharpen PyPI and server.json descriptions for discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Changed
+
+- **The one surface searchers actually reach now says what the tools do.** The 2026-08-20 discoverability baseline found exactly one organic path to this project: search snippets of the PyPI description mirrored by libraries.io, while the GitHub repository itself appeared in none of 72 checks. The PyPI summary now leads with the test problem and names the operations (probe, flash, reset, UART and CAN traffic, STM32), the keywords cover the terms real queries use (mcp-server, uart, can-bus, pyocd, pytest, hardware-testing), the project URLs add the changelog and the docs tree, and server.json describes the operations instead of the genre, so registries rendering it say what connecting an agent gets.
+
 ## [0.17.0] - 2026-08-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agentic-hil"
 version = "0.17.1.dev0"
-description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
+description = "A green build is not enough: Agentic Hardware-in-the-Loop (Agentic HIL) gives coding agents policy-gated MCP tools, and CI a pytest plugin, to probe, flash, reset, and exchange UART and CAN traffic with real embedded targets, including STM32, without a raw debugger shell."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -25,7 +25,15 @@ keywords = [
   "agentic-hil",
   "agentic",
   "agentic_hil",
-  "stm32"
+  "stm32",
+  "mcp-server",
+  "uart",
+  "can",
+  "can-bus",
+  "pyocd",
+  "pytest",
+  "hardware-testing",
+  "firmware-testing"
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -64,6 +72,8 @@ dev = [
 Homepage = "https://github.com/agentic-hil/agentic-hil"
 Repository = "https://github.com/agentic-hil/agentic-hil.git"
 Issues = "https://github.com/agentic-hil/agentic-hil/issues"
+Changelog = "https://github.com/agentic-hil/agentic-hil/blob/master/CHANGELOG.md"
+Documentation = "https://github.com/agentic-hil/agentic-hil/tree/master/docs"
 
 [project.scripts]
 agentic-hil = "agentic_hil.cli:entrypoint"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
-  "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+  "description": "Policy-gated MCP tools to probe, flash, reset, and exchange UART and CAN traffic with real embedded targets (STM32 and more) for hardware-in-the-loop testing by AI agents.",
   "version": "0.17.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -656,7 +656,7 @@ def contract_problems(root: Path) -> list[str]:
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
         "name": "io.github.agentic-hil/agentic-hil",
         "title": "Agentic HIL",
-        "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+        "description": "Policy-gated MCP tools to probe, flash, reset, and exchange UART and CAN traffic with real embedded targets (STM32 and more) for hardware-in-the-loop testing by AI agents.",
         "version": version,
         "repository": {
             "url": "https://github.com/agentic-hil/agentic-hil",


### PR DESCRIPTION
Sharpens the surfaces a searcher reaches:

- PyPI summary: leads with the test problem, then names the operations (probe, flash, reset, UART/CAN, STM32) and the policy gate.
- Keywords: adds mcp-server, uart, can, can-bus, pyocd, pytest, hardware-testing, firmware-testing.
- Project URLs: adds Changelog and Documentation.
- server.json description: operations instead of genre, effective with the next release.
- CHANGELOG entry under Unreleased.

No code changes.