### PR TITLE
chore(metadata): operations instead of genre on the surfaces a searcher reaches, with the registry length rule checked at PR time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Changed
+
+- **Somebody who reached the package through a search met a shelf label, on the one line every index and mirror prints next to the name.** The PyPI summary read "tools for AI-assisted embedded firmware loops" and the MCP registry description "for embedded hardware-in-the-loop testing on real devices": both name the category the project belongs to, neither names a single thing the tools do, so a reader who arrived while looking for a way to flash a board, reset it, read its UART or drive its CAN bus from an agent had nothing to recognise, and those surfaces truncate what they render, which puts the weight on the first words rather than on the whole sentence. The summary now opens on the problem the project exists for, in the README's own words, then the operations (probe, flash, reset, UART and CAN traffic, a real STM32 or other embedded target), then the policy gate that makes them safe to hand to an agent: one sentence, 271 characters against the 512 PyPI accepts, whose first 155 already carry every operation and the target. The keywords gain `mcp-server`, `uart`, `can`, `can-bus`, `pyocd`, `pytest`, `hardware-testing` and `firmware-testing` with none dropped, 21 terms the built metadata joins into 209 characters of the 512 that field allows. The project URLs gain `Documentation`, pointing at the rendered documentation site this repository already builds and declares in `mkdocs.yml` rather than at a directory listing of filenames, and `Changelog`, both labels PyPI renders as their own links in the sidebar. `server.json` names the operations too, in the same voice and inside the registry's own rules, and those rules are now checked here rather than at the end: the schema caps that description at 100 characters, the only thing enforcing the cap was `mcp-publisher validate` in the release job, which runs after the tag exists and after PyPI has the wheel, so the release contract measures the string as well as comparing it byte for byte, and a description one word too long is refused on the pull request that writes it. Nothing in `src/` changed. (#321)
+
 ## [0.17.0] - 2026-08-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agentic-hil"
 version = "0.17.1.dev0"
-description = "Agentic Hardware-in-the-Loop (Agentic HIL) tools for AI-assisted embedded firmware loops"
+description = "A green build is not enough: Agentic HIL lets an AI agent probe, flash, reset and exchange UART and CAN traffic with a real STM32 or other embedded target, through policy-gated MCP tools instead of a raw debugger shell, so hardware-in-the-loop tests run unattended in CI."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -25,7 +25,15 @@ keywords = [
   "agentic-hil",
   "agentic",
   "agentic_hil",
-  "stm32"
+  "stm32",
+  "mcp-server",
+  "uart",
+  "can",
+  "can-bus",
+  "pyocd",
+  "pytest",
+  "hardware-testing",
+  "firmware-testing"
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -62,7 +70,9 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/agentic-hil/agentic-hil"
+Documentation = "https://agentic-hil.readthedocs.io/"
 Repository = "https://github.com/agentic-hil/agentic-hil.git"
+Changelog = "https://github.com/agentic-hil/agentic-hil/blob/master/CHANGELOG.md"
 Issues = "https://github.com/agentic-hil/agentic-hil/issues"
 
 [project.scripts]

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
-  "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+  "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
   "version": "0.17.0",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
 from check_version_consistency import (  # noqa: E402
     DISTRIBUTION,
+    REGISTRY_DESCRIPTION_LIMIT,
     RELEASE,
     UNTRACKED_MENTIONS,
     contract_problems,
@@ -768,6 +769,23 @@ def test_a_persisted_plugin_mcp_command_is_refused(tree: Path) -> None:
     (tree / "plugins" / "agentic-hil" / ".mcp.json").write_text("{}", encoding="utf-8")
 
     assert any("MCP server command" in problem for problem in contract_problems(tree))
+
+
+def test_the_shipped_registry_description_fits_the_schema(tree: Path) -> None:
+    """The string this tree publishes, measured rather than trusted."""
+    registry = json.loads((tree / "server.json").read_text(encoding="utf-8"))
+
+    assert len(registry["description"]) <= REGISTRY_DESCRIPTION_LIMIT
+
+
+def test_a_registry_description_over_the_schema_limit_is_refused(tree: Path) -> None:
+    """`mcp-publisher validate` would refuse it at release, past the point of return."""
+    path = tree / "server.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["description"] = "x" * (REGISTRY_DESCRIPTION_LIMIT + 1)
+    path.write_text(json.dumps(document, indent=2), encoding="utf-8")
+
+    assert any("MCP registry schema allows" in problem for problem in contract_problems(tree))
 
 
 def test_the_printed_list_names_every_position_and_its_count() -> None:

--- a/tools/check_version_consistency.py
+++ b/tools/check_version_consistency.py
@@ -101,6 +101,13 @@ TAG_PIN = re.compile(r"""([^\s"'`@]+)@v(\d+\.\d+\.\d+)(?![\w.])""")
 # the copy it kept.
 INSTALL_SH_RELEASE = re.compile(r'^RELEASE="(\d+\.\d+\.\d+)"$', re.MULTILINE)
 INSTALL_PS1_RELEASE = re.compile(r"^\$Release = '(\d+\.\d+\.\d+)'$", re.MULTILINE)
+# The MCP registry schema server.json names declares `maxLength: 100` on
+# `description`, and `mcp-publisher validate` enforces it. That validation runs
+# in the release job, after the tag exists and after PyPI has the wheel, so a
+# description one word too long is discovered at the worst moment. The number
+# is restated here so a pull request that rewrites the description is refused
+# on the pull request instead.
+REGISTRY_DESCRIPTION_LIMIT = 100
 
 # The sweep walks the working tree, so it meets whatever else lives there.
 SKIPPED_DIRECTORIES = frozenset(
@@ -632,6 +639,12 @@ def contract_problems(root: Path) -> list[str]:
     Every version here is the release: a registry entry, a marketplace listing
     and an install command a reader copies all describe the release they can
     install, never the tree that is being worked on.
+
+    One field is measured as well as compared. The byte-for-byte comparison
+    speaks only for the string an earlier release already chose; the moment
+    somebody deliberately rewrites the description in both this file and
+    server.json, the registry schema's length rule is the only thing left that
+    can break, and it breaks in the release job rather than here.
     """
     version = release_version(root)
     found = []
@@ -656,7 +669,7 @@ def contract_problems(root: Path) -> list[str]:
         "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
         "name": "io.github.agentic-hil/agentic-hil",
         "title": "Agentic HIL",
-        "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
+        "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
         "version": version,
         "repository": {
             "url": "https://github.com/agentic-hil/agentic-hil",
@@ -678,6 +691,12 @@ def contract_problems(root: Path) -> list[str]:
     }
     if registry != expected_registry:
         found.append("server.json differs from the locally validated release contract")
+    described = registry.get("description")
+    if isinstance(described, str) and len(described) > REGISTRY_DESCRIPTION_LIMIT:
+        found.append(
+            f"server.json description is {len(described)} characters, over the "
+            f"{REGISTRY_DESCRIPTION_LIMIT} the MCP registry schema allows"
+        )
 
     expected_plugin = {
         "name": "agentic-hil",


### PR DESCRIPTION
Supersedes #316, redone from master with the release contract moved in lockstep.

- PyPI summary: one sentence, 271 of the 512 characters PyPI accepts, opening in the project's own voice ("A green build is not enough"), then the operations (probe, flash, reset, UART and CAN traffic, a real STM32 or other embedded target) and the policy gate. The first 155 characters, the window search snippets render, already carry every operation and the target.
- Keywords: adds mcp-server, uart, can, can-bus, pyocd, pytest, hardware-testing, firmware-testing; nothing dropped, 21 terms, 209 of the 512 characters the joined field allows.
- Project URLs: adds Documentation, pointing at the rendered docs site this repository already builds and declares in mkdocs.yml (verified live: HTTP 200 at /en/latest/), and Changelog. Both labels PyPI renders as their own sidebar links.
- server.json: "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated." That is 98 characters, and the number matters:

The finding that forced the redo: the MCP registry schema server.json names caps description at maxLength 100. The 171-character description on #316 passed the byte-comparison gate, because that gate only compares, and would have been refused by mcp-publisher validate in the release job, after the tag exists and after PyPI has the wheel. The release contract now measures the string as well (REGISTRY_DESCRIPTION_LIMIT = 100, regression-proven both ways), so a description one word too long is refused on the pull request that writes it.

PyPI shows the new summary with the next release. Follow-up for the docs site's own meta description: #319. The predecessor's red CI was two macOS flakes unrelated to metadata, #312 and #320.

Gates: full suite 2376 passed, ruff clean, python -m build and twine check PASSED, tools/check_version_consistency.py and tools/check_shipped_references.py exit 0; wheel METADATA inspected (summary single-line, keywords joined under the limit).