### PR TITLE
chore: begin 0.19.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.19.0"
+version = "0.19.1.dev0"
 description = "A green build is not enough: Agentic HIL lets an AI agent probe, flash, reset and exchange UART and CAN traffic with a real STM32 or other embedded target, through policy-gated MCP tools instead of a raw debugger shell, so hardware-in-the-loop tests run unattended in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.19.0"
+__version__ = "0.19.1.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager


### PR DESCRIPTION
Moves the distribution version past the 0.19.0 release; every release-pinned string stays at 0.19.0, exactly as the version gate demands between releases.