### PR TITLE
The hot-plug read claim cites its bench measurement, and the demo firmware carries the witness

### DIFF
--- a/examples/nucleo-f446re_demo/Src/main.c
+++ b/examples/nucleo-f446re_demo/Src/main.c
@@ -48,6 +48,31 @@
 #define USART_CR1_UE (1U << 13)
 #define USART2_BRR_115200_PCLK16MHZ 139U
 
+#define SYST_CSR (*(volatile uint32_t *)0xE000E010U)
+#define SYST_RVR (*(volatile uint32_t *)0xE000E014U)
+#define SYST_CVR (*(volatile uint32_t *)0xE000E018U)
+#define SYST_CSR_ENABLE (1U << 0)
+#define SYST_CSR_TICKINT (1U << 1)
+#define SYST_CSR_CLKSOURCE (1U << 2)
+#define SYSTICK_1MS_AT_16MHZ (16000U - 1U)
+
+/* A millisecond uptime counter in RAM: the witness a non-intrusive debug
+ * read is measured against. A read that resets or halts the core shows up
+ * here as a counter that jumped back or stopped advancing. */
+volatile uint32_t uptime_ms = 0U;
+
+void SysTick_Handler(void)
+{
+    uptime_ms++;
+}
+
+static void systick_init(void)
+{
+    SYST_RVR = SYSTICK_1MS_AT_16MHZ;
+    SYST_CVR = 0U;
+    SYST_CSR = SYST_CSR_CLKSOURCE | SYST_CSR_TICKINT | SYST_CSR_ENABLE;
+}
+
 void SystemInit(void)
 {
     /* Keep the reset clock defaults: HSI feeds APB1 at 16 MHz. */
@@ -93,6 +118,7 @@ static void delay(void)
 int main(void)
 {
     usart2_init();
+    systick_init();
 
     printf("Hello World\n");
     fflush(stdout);

--- a/src/agentic_hil/backends/stlink.py
+++ b/src/agentic_hil/backends/stlink.py
@@ -172,12 +172,12 @@ STLINK_CONNECT_MODES: dict[str, str] = {"hotplug": "HOTPLUG", "under_reset": "UR
 # the connects that reset; sending one alongside HOTPLUG would ask the least
 # intrusive connect for the thing it was chosen to avoid.
 #
-# What is documented is not what is measured. This encodes the least intrusive
-# connect the CLI documents, and it is strictly less intrusive than the NORMAL
-# it replaces; the proof that a read leaves a running core untouched is a bench
-# measurement (the #329 SysTick double-read, run again with this connect), and
-# it belongs to the operator and to issue #342. Nothing in a result claims that
-# proof: what a result carries is the log, and the log carries this argv.
+# Documented, and since 2026-08-30 also measured: issue #348 holds the bench
+# evidence, five SysTick pairs on a NUCLEO-F446RE advancing by wall time
+# through this connect, a deliberate reset control the counter detected, and
+# ten read logs carrying this argv with mode=HOTPLUG and no reset= option.
+# Nothing in a result claims the proof; what a result carries is the log,
+# and the log carries this argv.
 STLINK_READ_CONNECT_MODE: Literal["HOTPLUG"] = "HOTPLUG"
 
 STLINK_SERIAL_PATTERN = re.compile(r"^\s*ST-?LINK\s+SN\s*:\s*(\S+)\s*$", re.IGNORECASE | re.MULTILINE)


### PR DESCRIPTION
#348 asked for a bench measurement of the claim the ST-Link typed-debug reads ship with: that `mode=HOTPLUG` with no `reset=` leaves a running core untouched. The measurement is done and lives on the issue: five SysTick pairs on a NUCLEO-F446RE advancing by wall time through the read connect, a deliberate reset control the counter detected (21541 down to 3655), and ten read logs carrying the argv with `mode=HOTPLUG` and no `reset=` option.

Two changes follow from it:

- The comment on `STLINK_READ_CONNECT_MODE` stops saying documented-not-measured and cites the evidence instead. The pyOCD twin keeps its documented-only wording on purpose: its measurement is #349 and has not been run.
- `examples/nucleo-f446re_demo` gains the witness itself: a 1 ms SysTick counter `uptime_ms`, initialized in `main`, so the firmware the example builds is the firmware the measurement recipe needs, and re-running the proof on any bench starts at `flash_firmware` instead of at writing firmware.

Closes #348