### PR TITLE
Sweep the trusted-launcher directories interrupted suite runs leave in the real home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Fixed
+
+- **Every interrupted suite run left a trusted-launcher directory in the real home, and nothing ever collected them.** `tests/support.py` puts the launcher at `~/agentic-hil-pytest-launcher-<pid>` on purpose: the product's trust rule refuses an executable under a temp root or a group-writable directory, so `tmp_path` and `tempfile.gettempdir()` cannot hold one, and the real home is the single place that is both writable and trusted everywhere the suite runs. `tests/conftest.py` removed it in a session finalizer, and a finalizer only runs when the session ends on its own terms: a run that is killed, crashes or loses a worker never reached it, and because the name carries the pid, every such run left a fresh directory holding a stub `bin/agentic-hil`. One bench had collected eighteen of them, one per interrupted run over a few weeks. A session now sweeps its predecessors' leavings before its first test instead of trusting each of them to have cleaned up after itself. What may be taken is decided by the pid in the name and nothing else, with the liveness discipline `tools/run_lock.py` settled for exactly this question: on Windows a wait on the process handle, never `os.kill(pid, 0)`, which CPython maps onto `TerminateProcess` and which would answer the question by killing the run it was asked about. Every uncertain answer counts as alive, so a live pid, a pid this cannot get a readable answer about, a name that does not parse as one, and a directory this process may not delete are all left exactly where they stand; the only injury a sweep of shared space can do is deleting the launcher a suite running beside this one is still using, and a session's own launcher is held by that same rule, its pid being that very process. A removal that fails is silent and is not reported as swept, because another user's leftover is not this run's to judge and is never a reason to end a suite before its first test. The rule is spelled out again in `tests/support.py` rather than imported from `tools/`, which never ships: `tests/conftest.py` imports that module at module scope, and a test tree that reaches into `tools/` from there fails to collect out of a source distribution, so what the two must keep in step is the rule and not the code. (#385)
+
 ## [0.21.0] - 2026-09-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.0"
+version = "0.21.1.dev0"
 description = "A green build is not enough: Agentic HIL lets an AI agent probe, flash, reset and exchange UART and CAN traffic with a real STM32 or other embedded target, through policy-gated MCP tools instead of a raw debugger shell, so hardware-in-the-loop tests run unattended in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.0"
+__version__ = "0.21.1.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import yaml
 
 pytest_plugins = ["pytester"]
 
-from support import remove_trusted_launcher  # noqa: E402
+from support import remove_trusted_launcher, sweep_stale_launchers  # noqa: E402
 
 # Where every test's isolated HOME, config, state and temporary storage go.
 # Resolved once, here, out of the system temp root and before any test has
@@ -56,7 +56,14 @@ STALE_SANDBOX_AGE_S = 6 * 60 * 60
 
 @pytest.fixture(scope="session", autouse=True)
 def _clean_up_trusted_launcher() -> Iterator[None]:
-    """Remove the session's trusted launcher, wherever a test created it."""
+    """Remove the session's trusted launcher, wherever a test created it.
+
+    The sweep on the way in is what catches the sessions that never reached the
+    finalizer on the way out: a run that is killed or crashes leaves its
+    launcher in the real home under its own pid, and nothing else on the machine
+    knows what that directory is. It only ever removes a sibling whose pid names
+    no live process, so a suite running beside this one keeps its own."""
+    sweep_stale_launchers()
     yield
     remove_trusted_launcher()
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -13,7 +13,20 @@ REAL_HOME = Path(os.path.expanduser("~"))
 # does, and Local AppData was the wrong place anyway: a packaged host process
 # has its writes there redirected into its own LocalCache, so the launcher never
 # landed where the path said it did.
-LAUNCHER_ROOT = REAL_HOME / f"agentic-hil-pytest-launcher-{os.getpid()}"
+#
+# The pid is in the name so two suites on one machine never share a launcher,
+# and so a directory left by a run that never reached its finalizer can be
+# judged by the next run rather than accumulating forever (see
+# `sweep_stale_launchers`).
+LAUNCHER_PREFIX = "agentic-hil-pytest-launcher-"
+LAUNCHER_ROOT = REAL_HOME / f"{LAUNCHER_PREFIX}{os.getpid()}"
+
+# Windows, where `os.kill(pid, 0)` is not a liveness probe: CPython maps every
+# signal other than the console events onto TerminateProcess, so asking that
+# question there kills the run being asked about.
+_WINDOWS_SYNCHRONIZE = 0x00100000
+_WINDOWS_WAIT_OBJECT_0 = 0x00000000
+_WINDOWS_ERROR_INVALID_PARAMETER = 87
 
 
 def trusted_launcher() -> Path:
@@ -36,3 +49,122 @@ def trusted_launcher() -> Path:
 
 def remove_trusted_launcher() -> None:
     shutil.rmtree(LAUNCHER_ROOT, ignore_errors=True)
+
+
+def sweep_stale_launchers() -> list[Path]:
+    """Remove the launchers of runs that are no longer running, and say which.
+
+    `remove_trusted_launcher` only runs when a session ends on its own terms. A
+    run that is killed, crashes, or loses a worker never reaches it, and since
+    the name carries the pid, every such run leaves a fresh directory in the
+    real home: one bench had collected eighteen of them, one per interrupted run
+    over a few weeks. So a session cleans up after its predecessors instead of
+    trusting each of them to have cleaned up after itself.
+
+    A directory is removed only when this machine can prove nobody owns it. A
+    live pid, a pid this cannot get a readable answer about, a name that carries
+    no pid at all, and a directory this process is not allowed to delete are all
+    left exactly where they stand. That asymmetry is the whole design: the only
+    damage a sweep can do is deleting the launcher a suite running beside this
+    one is still using, and every uncertain answer therefore counts as alive.
+    """
+    removed: list[Path] = []
+    for candidate in sorted(LAUNCHER_ROOT.parent.glob(f"{LAUNCHER_PREFIX}*")):
+        # This session's own launcher needs no case of its own, which is the one
+        # way this differs from the sandbox sweep beside it: that one judges by
+        # age, and a long session's own root is exactly what looks old. Liveness
+        # cannot make that mistake, because the pid in this run's own name is
+        # this very process.
+        pid = _launcher_pid(candidate.name)
+        if pid is None or process_is_running(pid):
+            continue
+        try:
+            shutil.rmtree(candidate)
+        except OSError:
+            # Another user's leftover, or one this platform will not let go of
+            # while something still holds a file inside it. Not this run's to
+            # judge and never a reason to fail a suite, so it stays where it is
+            # and is not reported as removed.
+            continue
+        removed.append(candidate)
+    return removed
+
+
+def _launcher_pid(name: str) -> int | None:
+    """The pid a launcher directory's name carries, or None if it carries none.
+
+    Only the exact spelling `LAUNCHER_ROOT` writes counts, ascii digits naming a
+    real pid and nothing else. A name that does not parse is not something this
+    suite left behind, and a sweep has no business deleting a directory of
+    somebody else's that merely shares the prefix. `isdigit` is asked after
+    `isascii` because on its own it accepts spellings `int` then refuses,
+    superscripts among them.
+    """
+    suffix = name[len(LAUNCHER_PREFIX) :]
+    if not (suffix.isascii() and suffix.isdigit()):
+        return None
+    pid = int(suffix)
+    return pid if pid > 0 else None
+
+
+def process_is_running(pid: int) -> bool:
+    """Whether `pid` is a live process on this machine, without disturbing it.
+
+    The discipline `tools/run_lock.py` settled for exactly this question, spelled
+    out again here rather than imported. `tools/` is repository tooling that
+    never ships, `tests/conftest.py` imports this module at module scope, and a
+    test tree that reaches into `tools/` from there fails to collect out of a
+    source distribution; MANIFEST.in says so, and names the file that learned it
+    the hard way. What the two must keep in step is the rule, not the code.
+
+    Every uncertain answer is `True`, deliberately: this decides whether a
+    directory may be deleted out from under whoever owns it, so "I cannot tell"
+    means "leave it alone".
+    """
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    if os.name == "nt":
+        return _windows_process_is_running(pid)
+    try:
+        # Signal 0 checks for the process without delivering anything. Zero and
+        # negative pids are excluded above because they address process groups.
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # PermissionError says it exists and belongs to somebody else; anything
+        # else is an answer this cannot read, and both mean "do not touch it".
+        return True
+    return True
+
+
+def _windows_process_is_running(pid: int) -> bool:
+    """The same question on Windows, where `os.kill(pid, 0)` would answer it by
+    terminating the process. `WaitForSingleObject` on the process handle asks
+    without touching it: a live process is unsignalled, an exited one is
+    signalled at once. Exit codes are not consulted, because a process that
+    exited with 259 is indistinguishable from a running one through
+    `GetExitCodeProcess`, and this is the one call site where that matters."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    wait_for_object = kernel32.WaitForSingleObject
+    wait_for_object.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_object.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(_WINDOWS_SYNCHRONIZE, False, pid)
+    if not handle:
+        # Only "no such process" is a dead process. Access denied means it is
+        # alive and owned by somebody else, which is still alive.
+        return ctypes.get_last_error() != _WINDOWS_ERROR_INVALID_PARAMETER
+    try:
+        return wait_for_object(handle, 0) != _WINDOWS_WAIT_OBJECT_0
+    finally:
+        close_handle(handle)

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -367,6 +367,87 @@ def test_a_sandbox_root_is_swept_only_once_nobody_is_using_it() -> None:
         shutil.rmtree(stale, ignore_errors=True)
 
 
+def test_a_launcher_is_swept_only_once_its_run_is_gone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The leftover of a killed run, and the three neighbours around it.
+
+    The trusted launcher has to sit in the real home, and the finalizer that
+    removes it only runs when a session ends on its own terms. A run that is
+    killed or crashes leaves its directory behind under its own pid, so the
+    leftovers accumulate one per interrupted run until somebody notices
+    eighteen of them.
+
+    What the sweep may take is decided by the pid in the name and nothing else,
+    which is the whole of the risk: a suite running beside this one has a
+    launcher of its own in the same home, and deleting it mid-run is the one
+    injury a sweep of shared space can cause. So the four directories planted
+    here are the four answers that question has. The live pid is a child still
+    running, held open across the sweep rather than assumed alive. The dead one
+    is a child that has already exited, so the liveness this asserts is the real
+    one on both platforms, including the Windows handle wait that exists because
+    `os.kill(pid, 0)` would answer by terminating the process it was asked
+    about.
+
+    The home is this test's own, because the sweep is about a shared directory
+    and a fixture planted in the real one would be planting it beside every
+    other suite on the machine.
+    """
+    import support
+
+    home = tmp_path / "home"
+    own = home / f"{support.LAUNCHER_PREFIX}{os.getpid()}"
+    monkeypatch.setattr(support, "LAUNCHER_ROOT", own)
+    alive = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        ended = subprocess.Popen([sys.executable, "-c", ""])
+        ended.wait()
+        running = home / f"{support.LAUNCHER_PREFIX}{alive.pid}"
+        dead = home / f"{support.LAUNCHER_PREFIX}{ended.pid}"
+        unparsed = home / f"{support.LAUNCHER_PREFIX}not-a-pid"
+        for root in (own, running, dead, unparsed):
+            (root / "bin").mkdir(parents=True)
+            (root / "bin" / "agentic-hil").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+        removed = support.sweep_stale_launchers()
+
+        assert removed == [dead]
+        assert not dead.exists()
+        # A parallel suite's launcher, and the reason every uncertain answer
+        # counts as alive.
+        assert running.is_dir()
+        # Somebody else's directory that merely shares the prefix.
+        assert unparsed.is_dir()
+        # This session's own, which its own sweep must never take.
+        assert own.is_dir()
+    finally:
+        alive.kill()
+        alive.wait()
+
+
+def test_a_launcher_the_sweep_cannot_remove_is_left_where_it_stands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A removal that fails is not this suite's business to report or to fail on.
+
+    The home the launchers share is a real profile, and what sits in it beside
+    this run's directory can be another user's leftover or one the platform will
+    not let go of while something still holds a file inside it. Neither is a
+    reason to end a suite before its first test, and neither may be counted as
+    swept. Standing in for both here is the portable spelling of the same
+    refusal: an entry with a dead run's name that `rmtree` will not take.
+    """
+    import support
+
+    home = tmp_path / "home"
+    own = home / f"{support.LAUNCHER_PREFIX}{os.getpid()}"
+    monkeypatch.setattr(support, "LAUNCHER_ROOT", own)
+    own.mkdir(parents=True)
+    ended = subprocess.Popen([sys.executable, "-c", ""])
+    ended.wait()
+    refused = home / f"{support.LAUNCHER_PREFIX}{ended.pid}"
+    refused.write_text("not a directory, and not this sweep's to remove\n", encoding="utf-8")
+
+    assert support.sweep_stale_launchers() == []
+    assert refused.is_file()
+
+
 def test_a_test_that_undoes_its_own_monkeypatch_keeps_the_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
     """The one line that once aimed the whole suite at the operator's profile.
 


### PR DESCRIPTION
`tests/support.py` places the trusted launcher stub at `~/agentic-hil-pytest-launcher-<pid>` on purpose: the product's trust rule refuses an executable under a temp root or a group-writable directory, so the real home is the one place that is both writable and trusted everywhere the suite runs. The session finalizer that removed it only runs when a session ends on its own terms, so every killed, crashed or worker-lost run left a fresh directory behind; one developer machine had eighteen of them.

A session now sweeps its predecessors' leftovers before its first test. What may be taken is decided by the pid in the directory name and nothing else, with the liveness discipline `tools/run_lock.py` settled: on Windows a wait on the process handle, never `os.kill(pid, 0)` (CPython maps it to `TerminateProcess`), and every uncertain answer counts as alive. A live pid, an unreadable one, a name that does not parse, and a directory this process may not delete are all left where they stand, so a suite running beside this one keeps its launcher and a session's own launcher is protected by the same rule. A removal that fails is silent and not reported as swept.

The rule is spelled out again in `tests/support.py` rather than imported from `tools/`: `tests/conftest.py` imports that module at collection time, and a test tree that reaches into `tools/` from there fails to collect out of the source distribution (`tools/` never ships). Verified by building the sdist and collecting its tests.

The chain also carries the development version after 0.21.0.

Closes #385
