### PR TITLE
Publish pid and readiness markers atomically in the suite's process handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Fixed
+
+- The suite's spawned helpers now publish a pid or a readiness marker by writing it under a temporary name in the same directory and renaming it into place, and the parents that wait on those files wait for the value rather than for the name, with a budget that survives a slow interpreter start; a helper that created its pid file with a plain open left the name on the disk before the pid was in it, so a process-cleanup test on a loaded runner read a file that existed and was empty and failed converting it, and the same shape stood in every other pid and marker handshake across the process, loop, bench-mutex and coordination tests. (#395)
+
 ## [0.21.1] - 2026-09-03
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.1"
+version = "0.21.2.dev0"
 description = "A green build is not enough: Agentic HIL lets an AI agent probe, flash, reset and exchange UART and CAN traffic with a real STM32 or other embedded target, through policy-gated MCP tools instead of a raw debugger shell, so hardware-in-the-loop tests run unattended in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.1"
+__version__ = "0.21.2.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/tests/support.py
+++ b/tests/support.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import shutil
+import time
 from pathlib import Path
 
 # Captured before any test monkeypatches HOME.
@@ -27,6 +29,83 @@ LAUNCHER_ROOT = REAL_HOME / f"{LAUNCHER_PREFIX}{os.getpid()}"
 _WINDOWS_SYNCHRONIZE = 0x00100000
 _WINDOWS_WAIT_OBJECT_0 = 0x00000000
 _WINDOWS_ERROR_INVALID_PARAMETER = 87
+
+
+def publish_atomically(path: str, text: str) -> None:
+    """Give ``path`` its whole value in one step, so no reader ever sees it empty.
+
+    ``open(path, "w").write(value)`` puts the name on the disk first and the
+    value in it afterwards, and a reader that polls for the name can land in
+    between: a loaded `macos-latest` runner read a helper's pid file that existed
+    with nothing in it and converted the empty string (issue #395). Writing under
+    a temporary name in the same directory and renaming it over the target closes
+    that window, because a rename either has happened or has not: the name is
+    absent, or it carries the whole value.
+
+    The imports are inside the body because this function's own source is what
+    the suite's spawned helpers run. `PUBLISH_ATOMICALLY_SOURCE` is
+    `inspect.getsource` of it, so a helper in a fresh interpreter publishes by
+    the same rule the parent reads by, without importing anything from the suite
+    and without a second copy of the rule to keep in step.
+    """
+    import os
+    import time
+
+    temporary = f"{path}.publishing"
+    with open(temporary, "w", encoding="utf-8") as stream:
+        stream.write(text)
+    # Windows refuses a rename onto a name another process holds open, and a
+    # reader polling for the value is exactly such a process. That can only bite
+    # a second publication to the same name, since the first one has nothing to
+    # replace, but a helper must not die of it either way.
+    deadline = time.monotonic() + 5.0
+    while True:
+        try:
+            os.replace(temporary, path)
+            return
+        except PermissionError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+
+PUBLISH_ATOMICALLY_SOURCE = inspect.getsource(publish_atomically)
+
+
+def published(path: Path) -> bool:
+    """Whether ``path`` already carries a value published by the writer above.
+
+    The question a poller has to ask instead of `exists()`. Under the rename a
+    name that is there is complete, so the two answers agree; asking for the
+    value keeps them agreeing if a helper is ever written back to a plain open.
+    """
+    try:
+        return bool(path.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, PermissionError):
+        # Not there yet, or being renamed over on Windows. Both mean "not yet".
+        return False
+
+
+def read_when_published(path: Path, timeout_s: float = 5.0) -> str:
+    """Wait for ``path`` to carry a value and return it, stripped.
+
+    The default budget is the one #390's review settled for the same shape: a
+    fresh interpreter under `pytest -n auto` can take seconds just to start, so a
+    one second wait is not a helper that failed to publish, it is a runner under
+    load. Five seconds is a generous multiple of an interpreter start and still
+    fails the test rather than hanging it when a helper really never publishes.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except (FileNotFoundError, PermissionError):
+            text = ""
+        if text:
+            return text
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"{path} carried no published value within {timeout_s}s")
+        time.sleep(0.01)
 
 
 def trusted_launcher() -> Path:

--- a/tests/test_agentic_hil.py
+++ b/tests/test_agentic_hil.py
@@ -29,7 +29,7 @@ from conftest import (
     write_config,
 )
 from fixtures import fake_openocd
-from support import trusted_launcher
+from support import PUBLISH_ATOMICALLY_SOURCE, publish_atomically, read_when_published, trusted_launcher
 
 from agentic_hil import __version__
 from agentic_hil import process as process_module
@@ -6160,23 +6160,86 @@ def pid_alive(pid: int) -> bool:
         return False
 
 
+def test_a_published_pid_never_carries_its_name_before_its_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The window issue #395 was read through, closed at the writer.
+
+    `open(path, "w").write(pid)` publishes the name first and the value after it,
+    and every helper below is read by a parent that polls for that name: on a
+    loaded runner the parent won a race nobody meant to run and converted an
+    empty string. The publisher writes under another name in the same directory
+    and renames it over the target, so at the moment before the name appears the
+    whole value is already on the disk. The rename is watched rather than raced,
+    which is what makes this hold on an idle machine as firmly as on a loaded
+    one: with no rename there is no moment to watch, and the assertion below has
+    nothing to say about.
+    """
+    pid_file = tmp_path / "descendant.pid"
+    name_seen_before_the_value: list[bool] = []
+    real_replace = os.replace
+
+    def watched_replace(source: str, target: str) -> None:
+        if Path(target) == pid_file:
+            name_seen_before_the_value.append(pid_file.exists())
+        real_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", watched_replace)
+    publish_atomically(str(pid_file), "4321")
+
+    assert name_seen_before_the_value == [False], "the value reached its own name before the rename"
+    assert pid_file.read_text(encoding="utf-8") == "4321"
+    # And the name the value travelled under is gone, so a helper's directory is
+    # left exactly as a plain write would have left it.
+    assert list(tmp_path.iterdir()) == [pid_file]
+
+
+def test_a_pid_file_that_appears_before_its_value_is_waited_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other half of #395: what the parent does if the window opens anyway.
+
+    The failure was `int()` over whatever the name held the instant it appeared.
+    The reader waits for a value instead, so a name that arrives before its
+    content costs a wait rather than a `ValueError`. The value here is written
+    from inside the reader's own wait, which is what makes the proof exact: a
+    reader that converted the first thing it saw would never reach the write.
+    """
+    pid_file = tmp_path / "descendant.pid"
+    pid_file.write_text("", encoding="utf-8")
+    # The state the old parent stopped its poll on, and what it then converted.
+    assert pid_file.exists()
+    with pytest.raises(ValueError):
+        int(pid_file.read_text(encoding="utf-8"))
+
+    waits: list[float] = []
+
+    def fill_the_file_on_the_first_wait(seconds: float) -> None:
+        waits.append(seconds)
+        pid_file.write_text("4321", encoding="utf-8")
+
+    monkeypatch.setattr(time, "sleep", fill_the_file_on_the_first_wait)
+
+    assert int(read_when_published(pid_file)) == 4321
+    assert waits == [0.01], "the reader took the empty file rather than waiting for the pid"
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group cleanup regression")
 def test_process_cleanup_kills_sigterm_ignoring_descendant(tmp_path: Path) -> None:
     pid_file = tmp_path / "descendant.pid"
-    code = """
+    code = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import signal, subprocess, sys, time
 descendant = subprocess.Popen([sys.executable, '-c', 'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)'])
-open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
+publish_atomically(sys.argv[1], str(descendant.pid))
 signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(SystemExit(0)))
 time.sleep(30)
 """
+    )
     child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     try:
-        for _ in range(100):
-            if pid_file.exists():
-                break
-            time.sleep(0.01)
-        descendant_pid = int(pid_file.read_text(encoding="utf-8"))
+        # The pid, not the name: the helper's file used to appear empty and fill
+        # a moment later, and a poll that stopped at the name read "" off it
+        # (issue #395). One second was too short for the name as well, since a
+        # fresh interpreter under load can take longer than that just to start.
+        descendant_pid = int(read_when_published(pid_file))
 
         terminate_process_tree(child, 1.0)
 
@@ -6190,15 +6253,18 @@ time.sleep(30)
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group cleanup regression")
 def test_process_cleanup_handles_exited_group_leader(tmp_path: Path) -> None:
     pid_file = tmp_path / "descendant.pid"
-    code = """
+    code = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import signal, subprocess, sys
 descendant = subprocess.Popen([sys.executable, '-c', 'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)'])
-open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
+publish_atomically(sys.argv[1], str(descendant.pid))
 """
+    )
     child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     try:
         child.wait(timeout=5)
-        descendant_pid = int(pid_file.read_text(encoding="utf-8"))
+        descendant_pid = int(read_when_published(pid_file))
 
         terminate_process_tree(child, 1.0)
 
@@ -6305,14 +6371,17 @@ def test_process_cleanup_takes_an_already_gone_group_that_answers_esrch(monkeypa
 @pytest.mark.skipif(os.name != "nt", reason="Windows Job Object regression")
 def test_registered_windows_process_cleanup_kills_descendant_after_leader_exit(tmp_path: Path) -> None:
     pid_file = tmp_path / "descendant.pid"
-    code = """
+    code = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import subprocess, sys
 descendant = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])
-open(sys.argv[1], 'w', encoding='utf-8').write(str(descendant.pid))
+publish_atomically(sys.argv[1], str(descendant.pid))
 """
+    )
     child = spawn_managed_process([sys.executable, "-c", code, str(pid_file)])
     child.wait(timeout=5)
-    descendant_pid = int(pid_file.read_text(encoding="utf-8"))
+    descendant_pid = int(read_when_published(pid_file))
 
     terminate_process_tree(child, 1.0)
 
@@ -6404,7 +6473,7 @@ child = {function}(
     stdout=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,
 )
-open(sys.argv[1], "w", encoding="utf-8").write(str(child.pid))
+publish_atomically(sys.argv[1], str(child.pid))
 """
 
 
@@ -6424,9 +6493,11 @@ def grandchild_pid_after_spawner_exit(function: str, pid_file: Path) -> int:
     rather than a pipe. And the pid travels through a file rather than that
     stream, so nothing here depends on a descriptor the grandchild shares.
     """
-    spawner = subprocess.Popen([sys.executable, "-c", SPAWNER_SOURCE.format(function=function), str(pid_file)])
+    # Only the tail is formatted: the publisher's source carries braces of its own.
+    source = PUBLISH_ATOMICALLY_SOURCE + SPAWNER_SOURCE.format(function=function)
+    spawner = subprocess.Popen([sys.executable, "-c", source, str(pid_file)])
     assert spawner.wait(timeout=60) == 0
-    return int(pid_file.read_text(encoding="utf-8"))
+    return int(read_when_published(pid_file))
 
 
 def pid_alive_after_settling(pid: int, *, awaiting: bool, timeout_s: float = 5.0) -> bool:

--- a/tests/test_bench_mutex.py
+++ b/tests/test_bench_mutex.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 from conftest import write_config
+from support import PUBLISH_ATOMICALLY_SOURCE, publish_atomically, published, read_when_published
 
 from agentic_hil.bench import BenchMutex, DeviceBusyError, device_lock_root, is_physical_resource, resource_digest
 from agentic_hil.config import ConfigError, load_config
@@ -43,10 +44,15 @@ def child_environment(state_root: Path) -> dict[str, str]:
 
 
 def wait_for_file(path: Path, child: subprocess.Popen, timeout_s: float = 20) -> bool:
+    """Wait until the child has published `path`, or until it dies trying.
+
+    The wait is for the value rather than for the name: this file carries the
+    child's pid, and a name that is there is not yet a pid that is there unless
+    the writer renamed it into place (issue #395)."""
     deadline = time.monotonic() + timeout_s
-    while not path.exists() and child.poll() is None and time.monotonic() < deadline:
+    while not published(path) and child.poll() is None and time.monotonic() < deadline:
         time.sleep(0.02)
-    return path.exists()
+    return published(path)
 
 
 def holder_pid(ready: Path) -> int:
@@ -54,12 +60,7 @@ def holder_pid(ready: Path) -> int:
 
     On Windows a venv's ``python.exe`` re-launches the real interpreter, so
     Popen's pid is a redirector and not the owner; the child reports its own."""
-    for _ in range(200):
-        text = ready.read_text(encoding="utf-8").strip()
-        if text:
-            return int(text)
-        time.sleep(0.02)
-    raise AssertionError("child never reported its pid")
+    return int(read_when_published(ready))
 
 
 def test_device_lock_lives_outside_state_root_and_under_the_user_home(tmp_path: Path) -> None:
@@ -205,7 +206,9 @@ def test_two_state_roots_on_one_board_see_each_other(tmp_path: Path, monkeypatch
     config_path = write_config(tmp_path)
     ready = tmp_path / "child-ready"
     stop = tmp_path / "child-stop"
-    script = """
+    script = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import os, sys, time
 from pathlib import Path
 from agentic_hil.config import load_config
@@ -213,12 +216,13 @@ from agentic_hil.coordination import HardwareCoordinator
 config = load_config(sys.argv[1])
 coordinator = HardwareCoordinator(config, 'child')
 coordinator.begin_run(['physical:bench-board'], label='child-plan')
-Path(sys.argv[2]).write_text(str(os.getpid()), encoding='utf-8')
+publish_atomically(sys.argv[2], str(os.getpid()))
 while not Path(sys.argv[3]).exists():
     time.sleep(0.02)
 coordinator.end_run()
 coordinator.close()
 """
+    )
     environment = child_environment(tmp_path / "child-state")
     child = subprocess.Popen([sys.executable, "-c", script, str(config_path), str(ready), str(stop)], env=environment)
     try:
@@ -234,7 +238,7 @@ coordinator.close()
         assert result["holder"]["label"] == "child-plan"
         assert result["side_effect_committed"] is False
     finally:
-        stop.write_text("stop", encoding="utf-8")
+        publish_atomically(str(stop), "stop")
         child.wait(timeout=20)
 
 
@@ -246,17 +250,19 @@ def test_a_killed_run_frees_its_devices_without_operator_recovery(tmp_path: Path
     board back the moment the owner dies."""
     config_path = write_config(tmp_path)
     ready = tmp_path / "child-ready"
-    script = """
+    script = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import os, sys, time
-from pathlib import Path
 from agentic_hil.config import load_config
 from agentic_hil.coordination import HardwareCoordinator
 config = load_config(sys.argv[1])
 coordinator = HardwareCoordinator(config, 'child')
 coordinator.begin_run(['physical:bench-board'], label='doomed-plan')
-Path(sys.argv[2]).write_text(str(os.getpid()), encoding='utf-8')
+publish_atomically(sys.argv[2], str(os.getpid()))
 time.sleep(600)
 """
+    )
     environment = child_environment(tmp_path / "child-state")
     child = subprocess.Popen([sys.executable, "-c", script, str(config_path), str(ready)], env=environment)
     try:

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 import yaml
 from conftest import DEFAULT_TEST_PERMISSIONS, write_config
+from support import PUBLISH_ATOMICALLY_SOURCE, publish_atomically, published
 
 from agentic_hil import process as process_module
 from agentic_hil.bridge import BRIDGE_PROTOCOL_VERSION, BridgeCleanupError, ProcessBridgeSession
@@ -104,7 +105,9 @@ def test_pinned_state_root_coordinates_processes_with_different_environments(tmp
     config_path = write_config(tmp_path)
     ready = tmp_path / "owner-ready"
     stop = tmp_path / "owner-stop"
-    script = """
+    script = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import sys, time
 from pathlib import Path
 from agentic_hil.config import load_config
@@ -112,12 +115,13 @@ from agentic_hil.coordination import HardwareCoordinator
 config = load_config(sys.argv[1])
 coordinator = HardwareCoordinator(config, 'child')
 lease = coordinator.acquire('physical:shared-environment')
-Path(sys.argv[2]).write_text('ready', encoding='utf-8')
+publish_atomically(sys.argv[2], 'ready')
 while not Path(sys.argv[3]).exists():
     time.sleep(0.02)
 lease.release()
 coordinator.close()
 """
+    )
     environment = os.environ.copy()
     environment["LOCALAPPDATA"] = str(tmp_path / "child-state")
     environment["XDG_STATE_HOME"] = str(tmp_path / "child-state")
@@ -134,15 +138,19 @@ coordinator.close()
             coordinator.acquire("physical:shared-environment")
         assert excinfo.value.result["error_type"] == "resource_busy"
     finally:
-        stop.write_text("stop", encoding="utf-8")
+        publish_atomically(str(stop), "stop")
         child.wait(timeout=10)
 
 
 def wait_for_file(path: Path, child: subprocess.Popen, timeout_s: float = 10) -> bool:
+    """Wait until the child has published `path`, or until it dies trying.
+
+    For the value rather than for the name, which is what a file written under a
+    temporary name and renamed into place can promise (issue #395)."""
     deadline = time.monotonic() + timeout_s
-    while not path.exists() and child.poll() is None and time.monotonic() < deadline:
+    while not published(path) and child.poll() is None and time.monotonic() < deadline:
         time.sleep(0.02)
-    return path.exists()
+    return published(path)
 
 
 def test_different_projects_conflict_on_same_physical_resource(tmp_path: Path) -> None:
@@ -327,27 +335,26 @@ def test_direct_process_service_reaps_owned_orphans_before_close(
 def test_a_killed_owner_hands_its_devices_back_without_a_ritual(tmp_path: Path) -> None:
     config_path = write_config(tmp_path)
     marker = tmp_path / "owner-ready"
-    script = """
+    script = (
+        PUBLISH_ATOMICALLY_SOURCE
+        + """
 import sys, time
-from pathlib import Path
 from agentic_hil.config import load_config
 from agentic_hil.coordination import HardwareCoordinator
 config = load_config(sys.argv[1])
 coordinator = HardwareCoordinator(config, 'child')
 coordinator.acquire('physical:crash-test')
-Path(sys.argv[2]).write_text('ready', encoding='utf-8')
+publish_atomically(sys.argv[2], 'ready')
 time.sleep(60)
 """
+    )
     environment = os.environ.copy()
     dependency_root = str(Path(yaml.__file__).resolve().parents[1])
     source_root = str(Path(__file__).resolve().parents[1] / "src")
     environment["PYTHONPATH"] = os.pathsep.join([dependency_root, source_root, environment.get("PYTHONPATH", "")])
     child = subprocess.Popen([sys.executable, "-c", script, str(config_path), str(marker)], env=environment)
     try:
-        deadline = time.monotonic() + 10
-        while not marker.exists() and child.poll() is None and time.monotonic() < deadline:
-            time.sleep(0.02)
-        assert marker.exists(), "child did not acquire lease"
+        assert wait_for_file(marker, child), "child did not acquire lease"
     finally:
         child.kill()
         child.wait(timeout=10)

--- a/tests/test_loop_in_container.py
+++ b/tests/test_loop_in_container.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from support import PUBLISH_ATOMICALLY_SOURCE, published, read_when_published
 
 from evals.install import refresh_login
 from evals.install.credentials import authentication_failure, credential_health, spent_refresh_token
@@ -1519,8 +1520,10 @@ entrypoint.os.geteuid = lambda: 1000
 
 # The loop the entrypoint starts: announce that main() has reached its own
 # subprocess.run (so the stop signal below lands during the wait, with the
-# handler already installed) and then block until the signal kills it.
-blocker = "import pathlib, sys, time; pathlib.Path(sys.argv[1]).write_text('ready'); time.sleep(120)"
+# handler already installed) and then block until the signal kills it. The
+# announcement is renamed into place, like every other file this suite waits
+# on, so the waiter cannot be released by a name that is still empty.
+blocker = "import os, sys, time; open(sys.argv[1] + '.publishing', 'w').write('ready'); os.replace(sys.argv[1] + '.publishing', sys.argv[1]); time.sleep(120)"
 entrypoint.loop_command = lambda forwarded: [sys.executable, "-c", blocker, str(ready)]
 
 raise SystemExit(entrypoint.main(["--kinds", "codex-auth", "--", "--task", "x"]))
@@ -1553,7 +1556,7 @@ def _run_until_stopped_by(tmp_path: Path, sig: int) -> tuple[subprocess.Popen[by
         )
     try:
         deadline = time.monotonic() + 30
-        while not ready.exists():
+        while not published(ready):
             if process.poll() is not None:
                 pytest.fail(f"the harness exited before it started the loop:\n{log.read_text(errors='replace')}")
             if time.monotonic() > deadline:
@@ -5280,7 +5283,8 @@ def test_a_timed_out_agents_descendant_is_dead_and_silent_before_salvage(tmp_pat
     # write nothing now -- no post-kill wait has to guess when its write was due.
     grandchild_dormant = startup_budget + 10.0
     script.write_text(
-        "import os, pathlib, subprocess, sys, time\n"
+        PUBLISH_ATOMICALLY_SOURCE
+        + "import os, pathlib, subprocess, sys, time\n"
         "devnull = open(os.devnull, 'w')\n"
         # A grandchild that would write to the tree only long after the timeout,
         # then stay alive -- so a survivor is both a late write and a live process.
@@ -5291,7 +5295,10 @@ def test_a_timed_out_agents_descendant_is_dead_and_silent_before_salvage(tmp_pat
         "     \"time.sleep(120)\"],\n"
         "    stdout=devnull, stderr=devnull,\n"
         ")\n"
-        "pathlib.Path('child.pid').write_text(str(child.pid), encoding='utf-8')\n"
+        # Renamed into place rather than written into: the kill this test exists
+        # to fire can land between a plain open and its write, and then the read
+        # below has a name with nothing in it (issue #395).
+        "publish_atomically('child.pid', str(child.pid))\n"
         "sys.stdout.write('spawned\\n')\n"
         "sys.stdout.flush()\n"
         "time.sleep(120)\n",
@@ -5313,7 +5320,7 @@ def test_a_timed_out_agents_descendant_is_dead_and_silent_before_salvage(tmp_pat
     # _terminate_tree confirmed the group gone before run_agent raised, so the
     # descendant is dead here; having stayed dormant until well past the timeout,
     # it never wrote the marker before the kill and cannot write it now.
-    child_pid = int(child_pid_file.read_text())
+    child_pid = int(read_when_published(child_pid_file))
     assert not _pid_alive(child_pid), "a descendant survived the timeout"
     assert not marker.exists(), "a descendant wrote to the working tree after the timeout"
 
@@ -5338,7 +5345,8 @@ def test_terminate_tree_kills_a_child_that_outlived_its_reaped_group_leader(tmp_
     child_pid_file = workdir / "child.pid"
     script = tmp_path / "leader_that_exits.py"
     script.write_text(
-        "import os, pathlib, subprocess, sys\n"
+        PUBLISH_ATOMICALLY_SOURCE
+        + "import os, subprocess, sys\n"
         "devnull = open(os.devnull, 'w')\n"
         # A child left in the leader's own process group (no start_new_session), so
         # it stays in the group whose id is the leader's pid once the leader exits.
@@ -5346,7 +5354,7 @@ def test_terminate_tree_kills_a_child_that_outlived_its_reaped_group_leader(tmp_
         "    [sys.executable, '-c', 'import time; time.sleep(120)'],\n"
         "    stdout=devnull, stderr=devnull,\n"
         ")\n"
-        "pathlib.Path('child.pid').write_text(str(child.pid), encoding='utf-8')\n"
+        "publish_atomically('child.pid', str(child.pid))\n"
         # The leader returns here, leaving the child alive behind it.
         ,
         encoding="utf-8",
@@ -5364,7 +5372,7 @@ def test_terminate_tree_kills_a_child_that_outlived_its_reaped_group_leader(tmp_
     # the old code returned early on -- while its child lives on in the group whose
     # id is the leader's pid, which the kernel keeps reserved while a member remains.
     process.wait(timeout=30)
-    child_pid = int(child_pid_file.read_text())
+    child_pid = int(read_when_published(child_pid_file))
     assert _pid_alive(child_pid), "the child must outlive its leader for this test to mean anything"
     with pytest.raises(ProcessLookupError):
         os.getpgid(process.pid)
@@ -6332,7 +6340,10 @@ def _exploding_reader_thread(monkeypatch: pytest.MonkeyPatch, error: Exception, 
 
         def start(self) -> None:
             deadline = time.monotonic() + 30
-            while not_before is not None and not not_before.exists() and time.monotonic() < deadline:
+            # The published value, not the name: a name that appeared before its
+            # pid would release the failure a moment early, which is the one thing
+            # `not_before` exists to prevent.
+            while not_before is not None and not published(not_before) and time.monotonic() < deadline:
                 time.sleep(0.02)
             raise error
 
@@ -6455,25 +6466,30 @@ def _agent_with_a_descendant(tmp_path: Path, *, descendant_ignores_sigterm: bool
     members the reaper has not collected yet."""
     descendant = tmp_path / "descendant.py"
     descendant.write_text(
-        "import pathlib, signal, time\n"
+        PUBLISH_ATOMICALLY_SOURCE
+        + "import signal, time\n"
         + ("signal.signal(signal.SIGTERM, signal.SIG_IGN)\n" if descendant_ignores_sigterm else "")
-        + "pathlib.Path('child.ready').write_text('1', encoding='utf-8')\n"
+        + "publish_atomically('child.ready', '1')\n"
         "time.sleep(120)\n",
         encoding="utf-8",
     )
     script = tmp_path / "agent_with_a_descendant.py"
     script.write_text(
-        "import os, pathlib, subprocess, sys, time\n"
+        PUBLISH_ATOMICALLY_SOURCE
+        + "import os, pathlib, subprocess, sys, time\n"
         "devnull = open(os.devnull, 'w')\n"
         "child = subprocess.Popen(\n"
         "    [sys.executable, str(pathlib.Path(__file__).with_name('descendant.py'))],\n"
         "    stdout=devnull, stderr=devnull,\n"
         ")\n"
-        "pathlib.Path('child.pid').write_text(str(child.pid), encoding='utf-8')\n"
+        # Every name here is renamed into place, so a waiter that sees one has the
+        # whole value behind it: the pids the assertions convert, and the readiness
+        # this poll and the injected failure below both time themselves by.
+        "publish_atomically('child.pid', str(child.pid))\n"
         "ready, deadline = pathlib.Path('child.ready'), time.monotonic() + 30\n"
         "while not ready.exists() and time.monotonic() < deadline:\n"
         "    time.sleep(0.02)\n"
-        "pathlib.Path('agent.pid').write_text(str(os.getpid()), encoding='utf-8')\n"
+        "publish_atomically('agent.pid', str(os.getpid()))\n"
         "sys.stdin.read()\n",
         encoding="utf-8",
     )
@@ -6513,8 +6529,8 @@ def test_run_agent_kills_a_posix_agent_that_a_failure_after_the_launch_left_runn
             heartbeat=0,
         )
 
-    agent_pid = int((workdir / "agent.pid").read_text())
-    child_pid = int((workdir / "child.pid").read_text())
+    agent_pid = int(read_when_published(workdir / "agent.pid"))
+    child_pid = int(read_when_published(workdir / "child.pid"))
     assert not _pid_alive(agent_pid), "the agent survived the failure that ended its round"
     assert not _pid_alive(child_pid), "a descendant survived the failure that ended its round"
 


### PR DESCRIPTION
A process-cleanup test's helper created its pid file with a plain open, so the name reached the disk before the pid did; on a loaded macOS runner the parent, which polled only for the file's existence, read it empty and failed converting it. The same handshake shape stood in every other pid and marker exchange across the process, loop, bench-mutex and coordination tests.

Two shared helpers in `tests/support.py` now carry the rule on both sides: spawned helpers publish by writing under a temporary name in the same directory and renaming into place, and parents wait for a value rather than a name, with a budget that survives a slow interpreter start (the five seconds settled in #390). No test's claim changed, only how each waits.

The chain also carries the development version after 0.21.1.

Closes #395