### PR TITLE
Release 0.21.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
       "source": "./plugins/agentic-hil",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
-## [Unreleased]
+## [0.21.2] - 2026-09-04
 
 ### Added
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,7 +25,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix: all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.21.1"
+python -m pip install --user --upgrade "agentic-hil>=0.21.2"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -35,12 +35,12 @@ The one-line installer is that same fix in one command, and it repairs in place:
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.21.1" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.21.1 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.21.1"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.21.2" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.21.2 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.21.2"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.21.1" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.21.1"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.21.2" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.21.2"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Two Linux failures leave no installation behind and are not a broken machine. `error: externally-managed-environment` is PEP 668: Debian and Ubuntu mark the system Python as owned by the distribution and `pip` refuses it, `--user` included, so the pip block above does not apply on those hosts; `uv` and `pipx` install into environments of their own and need no exception. `invalid peer certificate: UnknownIssuer` from `uv`, or `self-signed certificate in certificate chain`, is a TLS-intercepting proxy: `uv` validates against roots bundled in its binary, while `curl` and `apt` on the same host read the system trust store and keep working, which is what makes the difference recognisable. `uv tool install --system-certs` (older releases: `--native-tls`) points `uv` at that same store. The one-line installers need to be told none of this: an install that fails with one of those messages is retried once against this machine's own store by itself, and says so while it does it. `--system-certs` (PowerShell `-SystemCerts`) skips the first attempt for a host known to sit behind such a proxy, and `--no-system-certs` refuses the retry for an operator who wants that decision made by nobody but themselves. Either way the installer exports `UV_SYSTEM_CERTS` for the whole run and, on Linux and macOS, points `pip` at the system bundle file it finds and names. Prefer `UV_SYSTEM_CERTS=1` in the operator's environment over the flag on a single command line: `agentic-hil upgrade` recognises the same signatures and retries the manager once against this machine's own store by itself (section 14 below), and an export is what spares every later upgrade that second attempt rather than paying for it each time. If `--system-certs` does not help, the proxy's CA is missing from the system trust store itself; installing it there is the fix, and `--allow-insecure-host` or any other switch that disables verification is not a fallback.
 

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -412,7 +412,7 @@ For release evaluation, use `target.mode: "remote"` with immutable values:
 ```json
 {
   "mode": "remote",
-  "expected_version": "0.21.1",
+  "expected_version": "0.21.2",
   "install_spec": "git+https://github.com/agentic-hil/agentic-hil@0123456789abcdef0123456789abcdef01234567",
   "expected_commit": "0123456789abcdef0123456789abcdef01234567"
 }

--- a/evals/install/matrix.example.json
+++ b/evals/install/matrix.example.json
@@ -12,7 +12,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.21.1"
+    "expected_version": "0.21.2"
   },
   "jobs": [
     {

--- a/evals/install/matrix.full.json
+++ b/evals/install/matrix.full.json
@@ -17,7 +17,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.21.1"
+    "expected_version": "0.21.2"
   },
   "jobs": [
     {

--- a/install.ps1
+++ b/install.ps1
@@ -29,7 +29,7 @@ $ErrorActionPreference = 'Stop'
 # Deliberately not a capability floor either: step 4 registers the skill out of
 # whatever copy step 1 left in place, so a floor left a returning user on an old
 # package and an old skill at once.
-$Release = '0.21.1'
+$Release = '0.21.2'
 $StepTotal = 5
 
 function Write-Say {

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ set -eu
 # untouched. Deliberately not a capability floor either: step 4 registers the
 # skill out of whatever copy step 1 left in place, so a floor left a returning
 # user on an old package and an old skill at once.
-RELEASE="0.21.1"
+RELEASE="0.21.2"
 
 AGENT=""
 WITH_AGENT_INSTALL=1

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench (flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports) or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware (PCB layout, schematic capture, EDA, mechanical design), and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.21.1"
+  agentic_hil_version: "0.21.2"
 ---
 
 # Agentic HIL
@@ -404,11 +404,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.21.1"
+uv tool install --upgrade "agentic-hil==0.21.2"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.21.1`. If `uv` is unavailable or a
+The version check must report exactly `0.21.2`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. `invalid peer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.2.dev0"
+version = "0.21.2"
 description = "A green build is not enough: Agentic HIL lets an AI agent probe, flash, reset and exchange UART and CAN traffic with a real STM32 or other embedded target, through policy-gated MCP tools instead of a raw debugger shell, so hardware-in-the-loop tests run unattended in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.2.dev0"
+__version__ = "0.21.2"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench (flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports) or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware (PCB layout, schematic capture, EDA, mechanical design), and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.21.1"
+  agentic_hil_version: "0.21.2"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
Stamps 0.21.2 across the files that carry the version, in lockstep with the changelog: the Unreleased section becomes the 0.21.2 section with today's date. The CI examples and their page already named this release as the one that carries the commands they call, and the version gate holds that pin to the stamp.

The release carries the work since 0.21.1: an operator-run upgrade is never refused for running servers and replaces the mapped Windows entrypoint itself; doctor reads state_root and a kept init says what it keeps; the COM session log is written in event order; a met comparator quotes what met it and every run keeps its own report copy; init --force works on the root it is meant to replace; the rendered result fails closed when it cannot be redacted; run-evidence turns a run report into the CI evidence bundle, redacted; worked GitHub Actions and GitLab CI examples for a self-hosted bench; and the suite's process handshakes publish pid files atomically.