### PR TITLE
Development version 0.21.4.dev0 after the 0.21.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
+### Changed
+
+- The tree carries the development version after 0.21.3, with the CI examples moved to the release they now build toward, as the version gate requires.
+
 ## [0.21.3] - 2026-09-05
 
 ### Added

--- a/docs/ci-examples.md
+++ b/docs/ci-examples.md
@@ -70,7 +70,7 @@ Both files carry one variable, `AGENTIC_HIL_VERSION`, set to the exact release
 these examples are written for:
 
 ```yaml
-AGENTIC_HIL_VERSION: "0.21.3"
+AGENTIC_HIL_VERSION: "0.21.4"
 ```
 
 An exact version, never a range, never `latest`, and never a git reference. A

--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -31,7 +31,7 @@ env:
   # simulator job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
-  AGENTIC_HIL_VERSION: "0.21.3"
+  AGENTIC_HIL_VERSION: "0.21.4"
 
 jobs:
   hardware:

--- a/examples/ci/gitlab-ci.yml
+++ b/examples/ci/gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:
   # simulator job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
-  AGENTIC_HIL_VERSION: "0.21.3"
+  AGENTIC_HIL_VERSION: "0.21.4"
 
 simulator:
   stage: simulate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.3"
+version = "0.21.4.dev0"
 description = "Hardware-in-the-loop MCP server for AI coding agents: develop firmware on the real board behind your debug probe, flashing, resetting and driving UART and CAN against it. The run on the hardware is the gate that decides the work is done, and a pytest plugin runs the same gate in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.3"
+__version__ = "0.21.4.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager


### PR DESCRIPTION
Moves the distribution version to 0.21.4.dev0 so an install from master no longer reports the published 0.21.3, opens the unreleased changelog section, and moves the three CI example files to 0.21.4, the release this tree now builds toward, as the version gate requires.