### PR TITLE
fix: keep MCP startup refusals off stdout

### DIFF
--- a/src/agentic_hil/cli.py
+++ b/src/agentic_hil/cli.py
@@ -263,10 +263,16 @@ def entrypoint(argv: list[str] | None = None) -> int:
     try:
         result = dispatch(args)
     except ConfigError as error:
-        emit_result(error.to_dict(), command, human=human)
+        if command in PROTOCOL_COMMANDS:
+            emit_protocol_error(error.to_dict(), command)
+        else:
+            emit_result(error.to_dict(), command, human=human)
         return 1
     except CoordinationError as error:
-        emit_result(error.result, command, human=human)
+        if command in PROTOCOL_COMMANDS:
+            emit_protocol_error(error.result, command)
+        else:
+            emit_result(error.result, command, human=human)
         return 1
     if isinstance(result, int):
         return result
@@ -328,6 +334,21 @@ def emit_result(result: JsonObject, command: str | None, *, human: bool) -> bool
         return True
     write_rendered(sys.stdout, render_result(redacted, command))
     return False
+
+
+def emit_protocol_error(result: JsonObject, command: str | None) -> None:
+    """Keep a startup refusal off a protocol command's stdout stream.
+
+    A protocol process owns stdout for framed messages, so a refusal raised
+    before the server can start must be visible on stderr instead of going
+    through the ordinary machine sink. Redaction still runs before the result
+    leaves the process; if it cannot vouch for the document, only the safe
+    refusal is written.
+    """
+    redacted = redact_sensitive(result)
+    if not isinstance(redacted, dict):
+        redacted = redaction_unavailable(command)
+    sys.stderr.write(json.dumps(redacted, indent=2) + "\n")
 
 
 def redaction_unavailable(command: str | None) -> JsonObject:

--- a/tests/test_human_readable_cli.py
+++ b/tests/test_human_readable_cli.py
@@ -237,6 +237,33 @@ def test_the_protocol_streams_are_never_rendered() -> None:
         assert cli.human_readable_output(command, json_requested=False) is False
 
 
+@pytest.mark.parametrize(
+    ("command", "extra_args"),
+    [("mcp-stdio", []), ("com-stdio", ["--port", "dut"])],
+)
+def test_a_protocol_startup_refusal_is_written_to_stderr(
+    monkeypatch: pytest.MonkeyPatch, command: str, extra_args: list[str]
+) -> None:
+    def refuse(args: argparse.Namespace) -> None:
+        raise cli.ConfigError(
+            "config_invalid",
+            "The authoritative configuration could not be loaded.",
+            {"field": "debuggers.dut.type"},
+        )
+
+    monkeypatch.setattr(cli, "dispatch", refuse)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr("sys.stdout", stdout)
+    monkeypatch.setattr("sys.stderr", stderr)
+
+    assert cli.entrypoint([command, *extra_args]) == 1
+    assert stdout.getvalue() == ""
+    refusal = json.loads(stderr.getvalue())
+    assert refusal["error_type"] == "config_invalid"
+    assert refusal["field"] == "debuggers.dut.type"
+
+
 def test_a_refusal_asked_for_as_a_document_is_still_the_document_it_was(monkeypatch: pytest.MonkeyPatch) -> None:
     def refuse(args: argparse.Namespace) -> None:
         raise cli.ConfigError("config_file_not_found", "No authoritative Agentic HIL configuration was found.", {"field": "workspace_root"})


### PR DESCRIPTION
## Summary

- Keep startup refusals for protocol-owned commands on stderr.
- Preserve redaction and the existing framed MCP stdout stream.
- Add regression coverage for both mcp-stdio and com-stdio.

Fixes #458

## Validation

- `ruff check src tests examples`
- `python -m pytest tests/test_human_readable_cli.py -q` (57 passed)
- `python -m pytest -n auto -q` (3152 passed, 99 skipped; one unrelated Windows baseline failure in test_devices.py using reserved name `com9`)
- `python -m build`
- `twine check`
- `python -m compileall -q src tests`
- Real subprocess check: invalid mcp-stdio configuration returned exit 1 with empty stdout and JSON refusal on stderr.