### PR TITLE
Release 0.21.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Agentic Hardware-in-the-Loop",
       "description": "Develop firmware on the real board behind a debug probe: flash, reset, UART and CAN, policy-gated.",
       "source": "./plugins/agentic-hil",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "license": "Apache-2.0"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
-## [Unreleased]
+## [0.21.4] - 2026-09-05
 
 ### Changed
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,7 +25,7 @@ Likely cause: Agentic HIL is not installed, `~/.local/bin` is not on `PATH`, or 
 Fix: all user-local, never with admin rights. Start with the PyPI/pip package:
 
 ```bash
-python -m pip install --user --upgrade "agentic-hil>=0.21.3"
+python -m pip install --user --upgrade "agentic-hil>=0.21.4"
 agentic-hil --version
 agentic-hil setup --help
 ```
@@ -35,12 +35,12 @@ The one-line installer is that same fix in one command, and it repairs in place:
 If that fails, use `uv` or `pipx` instead:
 
 ```bash
-uvx --from "agentic-hil>=0.21.3" agentic-hil --version                           # transient diagnostic only
-uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.21.3 agentic-hil --version # transient repository check
-uv tool install --upgrade "agentic-hil>=0.21.3"                                  # persistent user-local install
+uvx --from "agentic-hil>=0.21.4" agentic-hil --version                           # transient diagnostic only
+uvx --from git+https://github.com/agentic-hil/agentic-hil@v0.21.4 agentic-hil --version # transient repository check
+uv tool install --upgrade "agentic-hil>=0.21.4"                                  # persistent user-local install
 ```
 
-`pipx run --spec "agentic-hil>=0.21.3" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.21.3"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
+`pipx run --spec "agentic-hil>=0.21.4" agentic-hil --version` is also only a transient diagnostic; use `pipx install "agentic-hil>=0.21.4"` for a persistent installation. If `agentic-hil` is installed but not found, add the user-level executable directory to `PATH` with `uv tool update-shell` or `pipx ensurepath` and open a fresh shell. If neither `uv` nor `pipx` exists, install `uv` user-locally first (`curl -LsSf https://astral.sh/uv/install.sh | sh`). Never use `sudo pip` or `pip install --break-system-packages`.
 
 Three Linux failures leave no installation behind and are not a broken machine. `error: externally-managed-environment` is PEP 668: Debian and Ubuntu mark the system Python as owned by the distribution and `pip` refuses it, `--user` included, so the pip block above does not apply on those hosts; `uv` and `pipx` install into environments of their own and need no exception. `/usr/bin/python3: No module named pip` is that same block not applying for a plainer reason: Debian and Ubuntu servers, and most minimal container images, ship `python3` without the pip module unless `python3-pip` is installed, so there is no `pip` on that interpreter to run at all, while `uv` and `pipx` bring their own. `invalid peer certificate: UnknownIssuer` from `uv`, or `self-signed certificate in certificate chain`, is a TLS-intercepting proxy: `uv` validates against roots bundled in its binary, while `curl` and `apt` on the same host read the system trust store and keep working, which is what makes the difference recognisable. `uv tool install --system-certs` (older releases: `--native-tls`) points `uv` at that same store. The one-line installers need to be told none of this: an install that fails with one of those messages is retried once against this machine's own store by itself, and says so while it does it. `--system-certs` (PowerShell `-SystemCerts`) skips the first attempt for a host known to sit behind such a proxy, and `--no-system-certs` refuses the retry for an operator who wants that decision made by nobody but themselves. Either way the installer exports `UV_SYSTEM_CERTS` for the whole run and, on Linux and macOS, points `pip` at the system bundle file it finds and names. Prefer `UV_SYSTEM_CERTS=1` in the operator's environment over the flag on a single command line: `agentic-hil upgrade` recognises the same signatures and retries the manager once against this machine's own store by itself (section 14 below), and an export is what spares every later upgrade that second attempt rather than paying for it each time. If `--system-certs` does not help, the proxy's CA is missing from the system trust store itself; installing it there is the fix, and `--allow-insecure-host` or any other switch that disables verification is not a fallback.
 

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -494,7 +494,7 @@ revision that has no release behind it yet:
 ```json
 {
   "mode": "remote",
-  "expected_version": "0.21.3",
+  "expected_version": "0.21.4",
   "install_spec": "git+https://github.com/agentic-hil/agentic-hil@0123456789abcdef0123456789abcdef01234567",
   "expected_commit": "0123456789abcdef0123456789abcdef01234567"
 }
@@ -518,7 +518,7 @@ installs is what gets verified:
 ```json
 {
   "mode": "published",
-  "expected_version": "0.21.3",
+  "expected_version": "0.21.4",
   "guide_url": "https://raw.githubusercontent.com/agentic-hil/agentic-hil/master/AI_AGENT_QUICKSTART.md"
 }
 ```

--- a/evals/install/matrix.example.json
+++ b/evals/install/matrix.example.json
@@ -12,7 +12,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.21.3"
+    "expected_version": "0.21.4"
   },
   "jobs": [
     {

--- a/evals/install/matrix.full.json
+++ b/evals/install/matrix.full.json
@@ -17,7 +17,7 @@
   "timeout_seconds": 1800,
   "target": {
     "mode": "local",
-    "expected_version": "0.21.3"
+    "expected_version": "0.21.4"
   },
   "jobs": [
     {

--- a/install.ps1
+++ b/install.ps1
@@ -29,7 +29,7 @@ $ErrorActionPreference = 'Stop'
 # Deliberately not a capability floor either: step 4 registers the skill out of
 # whatever copy step 1 left in place, so a floor left a returning user on an old
 # package and an old skill at once.
-$Release = '0.21.3'
+$Release = '0.21.4'
 $StepTotal = 5
 
 # The PATH this run was handed, recorded before anything of ours has prepended to

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ set -eu
 # untouched. Deliberately not a capability floor either: step 4 registers the
 # skill out of whatever copy step 1 left in place, so a floor left a returning
 # user on an old package and an old skill at once.
-RELEASE="0.21.3"
+RELEASE="0.21.4"
 
 # The PATH this run was handed, recorded before anything of ours has prepended to
 # it. Step 3's report is about the operator's own shell, and this script edits

--- a/plugins/agentic-hil/.claude-plugin/plugin.json
+++ b/plugins/agentic-hil/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-hil",
   "displayName": "Agentic Hardware-in-the-Loop",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Develop firmware on the real board behind a debug probe: flash, reset, UART and CAN, policy-gated.",
   "author": { "name": "Hannes Pauli" },
   "repository": "https://github.com/agentic-hil/agentic-hil",

--- a/plugins/agentic-hil/skills/agentic-hil/SKILL.md
+++ b/plugins/agentic-hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench (flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports) or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware (PCB layout, schematic capture, EDA, mechanical design), and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.21.3"
+  agentic_hil_version: "0.21.4"
 ---
 
 # Agentic HIL
@@ -409,11 +409,11 @@ user-local executable, so it registers no MCP server command. Install the
 package version matching this plugin first:
 
 ```bash
-uv tool install --upgrade "agentic-hil==0.21.3"
+uv tool install --upgrade "agentic-hil==0.21.4"
 agentic-hil --version
 ```
 
-The version check must report exactly `0.21.3`. If `uv` is unavailable or a
+The version check must report exactly `0.21.4`. If `uv` is unavailable or a
 different `agentic-hil` resolves on `PATH`, stop and ask the operator to
 establish the trusted user-local prerequisite; do not substitute `uvx`, a
 workspace virtual environment, or an unversioned package. `invalid peer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.4.dev0"
+version = "0.21.4"
 description = "Hardware-in-the-loop MCP server for AI coding agents: develop firmware on the real board behind your debug probe, flashing, resetting and driving UART and CAN against it. The run on the hardware is the gate that decides the work is done, and a pytest plugin runs the same gate in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.agentic-hil/agentic-hil",
   "title": "Agentic HIL",
   "description": "Develop firmware on the real board behind a debug probe: flash, reset, UART and CAN, policy-gated.",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "repository": {
     "url": "https://github.com/agentic-hil/agentic-hil",
     "source": "github",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "agentic-hil",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.4.dev0"
+__version__ = "0.21.4"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager

--- a/src/agentic_hil/skills/agentic-hil/SKILL.md
+++ b/src/agentic_hil/skills/agentic-hil/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-hil
 description: Use when a request operates this project's connected target board through the configured bench (flashing, resetting, probing, debugging, UART and CAN stimulus and feedback, firmware artifacts, test reports) or configures Agentic HIL, the safe local MCP bridge that performs them. Use it instead of invoking a debugger, serial device, or CAN adapter directly. Not for designing hardware (PCB layout, schematic capture, EDA, mechanical design), and not for firmware authoring that never touches a board.
 metadata:
   origin: Agentic HIL
-  agentic_hil_version: "0.21.3"
+  agentic_hil_version: "0.21.4"
 ---
 
 # Agentic HIL


### PR DESCRIPTION
Release 0.21.4: the distribution version, the CHANGELOG heading and every released-version position the consistency check tracks move from 0.21.3 to 0.21.4; the CI examples already state 0.21.4 and stay. Tag, GitHub release, PyPI publish and the installer upload follow the merge. Release notes:

### Changed

- The outermost `summary` of a test plan refused because a permission denied a step now names that permission and says this bench's policy refused the plan, rather than reporting that the configuration failed semantic validation, which sent a caller or an agent that reads only that string to correct a document with nothing wrong with it; the sentence stays neutral about which way the key has to move, because a permission refuses by being closed and `allow_mass_erase` refuses by being open, every refusal whose cause really is the plan keeps the sentence it had, and the `validation_error` block, the top-level `permission` field and the `permission_denied` classification are exactly as they were. (#468)
- The restart advice `agentic-hil upgrade` prints names the agent hosts that have this server registered and says nothing at all when none does, instead of printing `restart agent hosts to load the new MCP server` beside its own `refreshed` block reporting nothing to refresh for any of the three; the step before a reinstall is chosen by the host it will be run on, so the one about closing the agent host because the environment has to be deleted first is printed only where a running image cannot be replaced, and every other host reads the sentence that is true there, that the reinstall goes through while a server already running keeps answering with the release it imported; the pin refusal says whose words the relayed block is and what following them costs before the operator reads it, with uv's own text left under `install` unedited for `--json`; and the human rendering prints the line it tells the reader to run, `reinstall_command` beside `installed_extras`, `with_packages`, `recorded_python`, `pinned_version`, `already_current`, `newest_release`, `held_back_by` and `with_packages_not_replayed` wherever a result carries them, since it had printed none of those and left uv's own hint as the only runnable command on a screen whose prose tells the reader not to run it. (#461)
- `install.sh` and `install.ps1` close a run that replaced an existing installation on the sentence that fits it: the installation was refreshed in place, project configurations were not touched, and any agentic-hil MCP server still running keeps answering with the release it started with until the agent CLI that started it is restarted. The first-install sentence, about the next start of the agent having everything and the first hardware question creating this project's configuration, stays for a first install and no longer greets a host that already has configurations of its own. Both scripts decide on a flag of their own rather than on the install mode, because the branch that keeps a development tree installs nothing at all and is still a machine that already has this tool. (#462)
- A test-reactor result that executed its steps and failed its claim is now headed by the run's outcome, `Failed: comparator_unmet`, and `Refused:` is reserved for results where no step ran, so a deliberate red run no longer reads like a setup error; the heading is decided by the fields that say whether anything happened, a non-empty step list and a committed side effect, and everything under it is unchanged. (#447)
- A configuration write from the command line now records the surface it came through instead of claiming a person made it: `human` where an interactive terminal answers and `cli` otherwise, with `last_modified_via` naming the command either way, because the same command is also what a shell script, a CI step and a provisioning tool run; nothing about authorization moves and writes over MCP are recorded exactly as before. (#452)
- `agentic-hil check-plan` now reports, per plan, the device names a plan uses that this workspace's configuration does not declare, in the output and in `--json`, so a plan the bench would refuse at its first step is caught before a board is touched; it is a finding rather than a failure because a repository holds plans for benches other than the one a checkout sits on, `--strict` turns findings into a nonzero exit, and a workspace with no configuration is told so and has its plans checked for loadability alone; a configuration that is present but will not load -- malformed, unreadable, noncanonical or bound to another workspace -- is reported as such and, because it is a broken bench rather than no bench, fails `--strict` instead of passing a preflight it could not perform. (#453)
- `agentic-hil com-ports` and every refusal that embeds the host port inventory now list the ports carrying a USB identity, a vendor id, a product id or a serial number, in full and collapse the rest to one line with their count and the names they run between, so a host's three dozen legacy serial stubs no longer stand between a reader and the one board that matters; `--json` is unchanged and still carries every port. (#454)
- The tree carries the development version after 0.21.3, with the CI examples moved to the release they now build toward, as the version gate requires.

### Fixed

- The `Configuration digest` row of the job summary `agentic-hil run-evidence` writes prints one algorithm-prefixed digest instead of joining `digest_algorithm` onto a `config_digest` that already carries its own prefix, which published `sha256sha256:4cdb...` in the one artifact a reviewer holds against the configuration; the row now serves a report whose digest field carries the prefix and one whose digest is bare hex, and the run summary's own fields, which were each correct already, are unchanged. (#466)
- `agentic-hil check-plan --strict` that exits 1 is headed by its outcome and the count it failed on, `Failed: 1 of 1 test plan(s) name device(s) this workspace's configuration does not declare (dut_uart2)`, instead of opening on `All 1 test plan(s) load through the reactor's loader` and leaving the only nonzero signal in a subordinate clause at the end; the same heading covers the other strict failure, a configuration that is present and cannot be read, every plan naming an undeclared device now carries that finding as its own sentence rather than being introduced by the word `ok` with the device filed underneath it, and the non-strict run, which exits 0 because a repository holds plans for benches other than the one a checkout sits on, keeps the informational heading it had. (#467)
- `agentic-hil upgrade`'s `upgrade_blocked_by_pin` refusal reads `uv`'s own `uv-receipt.toml` before it prints the line it promises will keep the installation whole: every requirement the receipt records beside this distribution is carried into `reinstall_command` as its own `--with`, environment marker included, a recorded interpreter as `--python`, read from the `[tool]` level as current uv writes it and from `[tool.options]` as older uv did, and all of them are named on the result under `with_packages` and `recorded_python` beside `installed_extras`, with the summary saying in words what the bare `uv tool install "agentic-hil@latest"` of uv's own hint would uninstall instead. A pinned installation carrying `--with pytest` had run that promised remediation verbatim and watched uv answer `Uninstalled 5 packages`, pytest among them, because the line named the distribution alone. A requirement the receipt records as a git, url or path source, or in parts that are not a PEP 508 requirement, is not respelled into something that installs differently: it is named under `with_packages_not_replayed` with the receipt member that stops it and said out loud in the summary, rather than disappearing from a line whose own sentence promises to rebuild this installation as it stands. Every replayed value is quoted for the shell the line is pasted into, so a receipt entry carrying shell punctuation can no longer end up as a printed command that is not the command it prints, and a receipt that cannot be read leaves the line exactly as it was. (#456)
- `already_current` is asserted only after the newest release has been read from the index, over one HTTPS request bounded by a wall clock as well as by the socket timeout, instead of from a package manager's `Nothing to upgrade` alone: an index that did not answer, or that trickled bytes past the budget, takes the claim off the result and says the newest release could not be checked, an installation level with the index is told so and one above it is told it is a build ahead rather than on the release below it, and a receipt that records an `exclude-newer` or an exact `==` requirement while the index publishes something newer answers the new `upgrade_blocked_by_recorded_option`, names what holds the installation where it is under `held_back_by` beside `newest_release`, and carries the `uv tool install` line that records the installation again without it, with the extras, the `--with` packages and the interpreter it already has. An installation had been called current two hours after the next release was published, with a follow-up sentence pointing at its recorded requirement, which was unpinned; uv records `exclude-newer` whether it was given as a flag or through the environment and offers no command that clears it. That outcome is a refusal and exits non-zero, and it is reserved for a recorded requirement or option that is demonstrably keeping this installation below a release the index publishes: a `>=` or `~=` floor resolves to whatever the index offers above it, so it holds nothing back, and an installation created with one exits 0 like a current one, which is what a provisioning script running this command unconditionally needs. An installation pinned to the release it is already on keeps the note it had, with its exit code, and loses only the claim to be the newest there is. (#457)
- `agentic-hil mcp-stdio` and `agentic-hil com-stdio` no longer write a startup refusal to stdout, the stream a client frames as protocol messages: a configuration the server cannot load is reported on stderr as a redacted JSON document, stdout stays empty, and the exit code stays 1, so the client sees no unparseable output and the operator can read why the server did not start (#458, pull request #463).
- The process table is read out of `/proc` on Linux as well as through the Windows snapshot, so `agentic-hil upgrade` can name the servers running out of the installation it has just replaced: each is reported under `restart_required_by` with its pid, when it started, and the directory it was started in where the host can read it, which on Linux is the project its host opened an MCP server for and which Windows does not answer at all, and the summary names them rather than reading the same with a live server as with nothing running at all. A process belongs to this installation when its image sits under the environment, when the path it was invoked by does, or when its environment carries `VIRTUAL_ENV` pointing at it, because a POSIX virtual environment's `bin/python` is a symlink to the system interpreter and reading the resolved image alone matched nothing a Linux bench ever started. The start time is the kernel's own record of when the process began rather than a timestamp procfs sets when the entry is first looked at, which reported every server as having started at the moment it was asked about. `restart_required` follows what was found instead of being set on every upgrade: true when such a process exists, false when the table was read and held none, absent, with a sentence saying so, on a host that publishes no process table, true on a run that moved the version where an agent host has this server registered, and true on an installation that nothing replaced while a server started before the last upgrade is still up, which is the case that used to answer false, on the exact-pin refusal as much as on the two answers that call an installation current. A creation time at or below the Unix epoch is never rendered as a date, so the two hosts no longer disagree about what a result claims. Nothing is refused and nothing is delayed. (#459)
- A configuration written by a newer Agentic HIL is no longer refused as a bare unknown field with a list of allowed keys and no way forward: the refusal names every key it rejected, and where the file records under `provenance.agentic_hil_version` a release newer than the one reading it, the refusal says that, reports both releases and names `agentic-hil upgrade` as the next step, while a file this release or an older one wrote keeps the refusal pointed at the misspelling. The release is read out of the file because no build can recognise the field names a later release adds: the table of which release introduced which field only ever holds this build's own fields, so the sentence it guarded could not fire on any shipped installation against the very file it was written for; the table stays as a refinement for a document that records no provenance at all. Every `config_invalid` refusal now carries the error catalogue's remediation the way its neighbours do, and unknown keys are still refused on both routes. (#460)
- `agentic-hil adopt-hardware --dry-run` now shows both sides of every compared key and names the value adoption keeps, instead of rendering `configured not set, attached not set` over a plan whose JSON carried both, and `target.controller` says why a configured part number outranks the family name a target script reports. (#442)
- Every refusal caused by a permission now names that permission: the result carries `permission` as the dotted key the configuration file uses and `agentic-hil grant` takes, names it in the summary sentence an agent reads out, and its next step still says to report the refusal and stop while handing the operator the exact one-key grant line, so a caller instructed to name the permission it was denied can comply and an operator no longer has to go hunting through the file for it; the opposite case, an action blocked by a permission that is open, names the same key and the command that closes it, because sending an operator to grant that flag is the one move that keeps the action refused. (#443)
- A test plan step the configuration's permissions deny is refused as `permission_denied` on the command line as well as over MCP, at the top level, as the finding's own error type and under `step_error_type`, instead of `test_config_invalid`, which said the plan was at fault when the plan was valid and the bench had said no; and the `test_config_invalid` advice now offers `agentic-hil init --force` only for the empty configuration section it actually answers and names it among the things not to do everywhere else, because by its own text that command replaces the whole file, every narrowed permission included. (#444)
- `agentic-hil debugger-probes` now exits 0 when the discovery answered, so an OpenOCD bench whose USB-serial enumeration can never report itself complete stops failing `set -e` scripts over a working read; `complete: false` rides the result, is named in the summary and is printed beside the backend, and the nonzero exit is reserved for a discovery that failed. (#445)
- The human rendering of a refused test plan prints `validation_error.next_step`, the one line naming the exact command that fixes that plan, which the document carried and the screen dropped while the advice above it opened by telling the reader to go and read it; that pointer is now printed only when the field is there to be read, and the advice a refusal and its finding both resolve to is printed once rather than twice. (#446)
- The refusal for a test plan whose path resolves outside `workspace_root` now carries the one move that fixes it and names the configured workspace root the plan has to sit under, instead of the five steps about device names, hardware adoption, `init --force` and plan schema versions that belong to a plan whose contents are wrong; that refusal is raised before the file is opened, so none of the advice it used to print was about anything that had been read. (#448)
- `agentic-hil grant` and `agentic-hil revoke` now say in the result that `side_effect_committed`, `side_effect_status` and `hardware_state` describe hardware and that the configuration write is reported under `changed`, so a caller reading those fields to learn whether the file moved is no longer told no after a successful write; the values themselves stay exactly as `project_config_set`, `adopt-hardware --apply` and `init` report them. (#449)
- `agentic-hil upgrade` on an installation pinned to the release it is already running now exits 0 and reports the pin with its reinstall command as a note, instead of refusing with `upgrade_blocked_by_pin` and exit 1 over an installation that is current; the refusal is reserved for a pin that holds a newer release back. (#450)
- A refusal rendered for the command line now names the command a person can type for every tool it recommends, so a reader is sent to `agentic-hil debugger-probes` rather than to `debugger_probes_list`, which exists only over MCP; the JSON document keeps the tool name for the caller that parses it, a step that names the MCP surface keeps its tool name on both surfaces, and every tool the error catalogue recommends is now declared as either having a command or keeping its name. (#451)
- `agentic-hil run-evidence` now writes an elapsed time in every step row of the job summary, COM steps included, because the reactor times each step it runs rather than the table taking whatever duration the tool underneath happened to report, which only the debugger backends do; a report written before this still reads, falling back to the tool's own duration where a step carries none. (#455)
