### PR TITLE
Name the board-free CI example job and the check-plan help for what they do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Changed
+
+- The board-free job in the shipped CI examples is named `check-plan`, after the command it runs, and neither the examples nor `check-plan`'s own help calls it a simulator any more: the job installs the pinned release and loads every plan through the reactor's own loader, it runs no firmware and it models no electrical behaviour, so the word promised an emulation the product has never contained, beside comments and results that already said the job establishes nothing electrical. `examples/ci/github-actions.yml` and `examples/ci/gitlab-ci.yml` rename the job, and on GitLab the stage it runs in, so a copied file names it after what it does; their header comments and `docs/ci-examples.md` now state that a green run of it says nothing about a board and everything about the plans, and the `check-plan` help and docstrings say board-free or without a bench where they said hosted simulator. Nothing a job runs, refuses, pins or uploads changes, and the command keeps every option, output field and exit code it had. (#471)
+
 ## [0.21.4] - 2026-09-05
 
 ### Changed

--- a/docs/ci-examples.md
+++ b/docs/ci-examples.md
@@ -5,7 +5,7 @@ runner is set up and the release they pin is published:
 
 - [`examples/ci/github-actions.yml`](https://github.com/agentic-hil/agentic-hil/blob/master/examples/ci/github-actions.yml):
   a GitHub Actions workflow with a hardware job on a self-hosted runner and a
-  simulator job on a hosted runner beside it.
+  board-free `check-plan` job on a hosted runner beside it.
 - [`examples/ci/gitlab-ci.yml`](https://github.com/agentic-hil/agentic-hil/blob/master/examples/ci/gitlab-ci.yml):
   the same two jobs for GitLab CI.
 
@@ -55,14 +55,15 @@ by the workflow, and none of it can be.
   Windows bench that is the shell Git for Windows installs, which the GitHub
   runner already selects for `shell: bash`.
 
-The hosted simulator job needs none of this. It installs the pinned release
+The hosted `check-plan` job needs none of this. It installs the pinned release
 from the package index and loads each plan through the reactor's own loader with
-`agentic-hil check-plan`, and that is the whole of it. That command is the
-loadability check the job exists for: it calls the same `load_test_config` the
-bench would, so a plan it accepts is one the reactor can load, where a
-schema-only reader would pass a plan using a key from a later plan version, or
-one with the duplicate keys the real loader refuses, and let the failure reach
-the bench.
+`agentic-hil check-plan`, and that is the whole of it: it runs no firmware and
+models no electrical behaviour, so a green run of it says nothing about a board
+and everything about the plans. That command is the loadability check the job
+exists for: it calls the same `load_test_config` the bench would, so a plan it
+accepts is one the reactor can load, where a schema-only reader would pass a
+plan using a key from a later plan version, or one with the duplicate keys the
+real loader refuses, and let the failure reach the bench.
 
 ## The version pin
 
@@ -87,22 +88,22 @@ That "builds toward" is why the caveat above says *once the release they pin is
 published*. On a release commit the release being cut is the one the examples
 pin, so the file a reader receives in that release pins a version already on the
 index. On `master` between releases the pin names the next release, which the
-index does not carry yet: copying the simulator job before that release exists
-installs nothing, and the previous release does not expose the commands these
-examples were written to show. Pinning the previous release instead would name a
-distribution a reader can install today but that rejects `check-plan` and
-`run-evidence` at argument parsing, which is the worse of the two. The publish
-workflow closes the loop rather than leaving it to trust: after PyPI accepts a
-release, `tools/verify_published_examples.py` installs exactly the pinned
-distribution and confirms its CLI reports that version and answers every command
-the examples invoke, so a release whose artifact does not match its own examples
-is an alarm on the release and not a stranger's failed copy.
+index does not carry yet: copying the `check-plan` job before that release
+exists installs nothing, and the previous release does not expose the commands
+these examples were written to show. Pinning the previous release instead would
+name a distribution a reader can install today but that rejects `check-plan`
+and `run-evidence` at argument parsing, which is the worse of the two. The
+publish workflow closes the loop rather than leaving it to trust: after PyPI
+accepts a release, `tools/verify_published_examples.py` installs exactly the
+pinned distribution and confirms its CLI reports that version and answers every
+command the examples invoke, so a release whose artifact does not match its own
+examples is an alarm on the release and not a stranger's failed copy.
 
 The same rule reaches everything else the jobs fetch. Actions are pinned by
 commit SHA with the tag they stood for in a trailing comment, not by tag. No
 step pipes a script from the network into a shell. If you give the GitLab
-simulator job an `image:`, pin it by digest, because a floating tag is the same
-unversioned download in another spelling.
+`check-plan` job an `image:`, pin it by digest, because a floating tag is the
+same unversioned download in another spelling.
 
 ## What the jobs leave behind
 

--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -5,9 +5,10 @@
 #
 # Two jobs, because there are two paths and a reader has to see both in one
 # file. `hardware` runs the plans on a self-hosted runner that has the board.
-# `simulator` runs on a hosted runner, has no bench, establishes nothing
-# electrical, and checks that the plans themselves are loadable: the cheapest
-# place to find a broken plan is here, and the most expensive is the bench.
+# `check-plan` runs on a hosted runner, has no bench, runs no firmware and
+# models no electrical behaviour, so it establishes nothing electrical; what it
+# checks is that the plans themselves are loadable, and the cheapest place to
+# find a broken plan is here while the most expensive is the bench.
 #
 # What the runner has to provide before this workflow can run at all is in
 # docs/ci-examples.md. Nothing here installs Agentic HIL, writes a
@@ -28,7 +29,7 @@ permissions:
 env:
   # The exact release this workflow is written against. The hardware job holds
   # the bench's own installation to it and stops when they disagree; the
-  # simulator job installs exactly it. No range, no `latest`, no git reference:
+  # check-plan job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
   AGENTIC_HIL_VERSION: "0.21.5"
@@ -173,13 +174,14 @@ jobs:
             .agentic-hil/reports/
           if-no-files-found: warn
 
-  simulator:
+  check-plan:
     # The other path. No bench, no board, so any hosted runner will do, and it
     # runs on every pull request including the ones from forks: there is
-    # nothing here for a fork to reach. It establishes nothing electrical. What
-    # it does establish is that every plan in this repository is one the
-    # reactor could load, which is the failure worth finding before anybody
-    # carries a board to it.
+    # nothing here for a fork to reach. It runs no firmware and models no
+    # electrical behaviour, so it establishes nothing electrical. What it does
+    # establish is that every plan in this repository is one the reactor could
+    # load, which is the failure worth finding before anybody carries a board
+    # to it.
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/examples/ci/gitlab-ci.yml
+++ b/examples/ci/gitlab-ci.yml
@@ -5,9 +5,10 @@
 #
 # Two jobs, because there are two paths and a reader has to see both in one
 # file. `hardware` runs the plans on a runner that has the board attached.
-# `simulator` needs no bench, establishes nothing electrical, and checks that
-# the plans themselves are loadable: the cheapest place to find a broken plan
-# is here, and the most expensive is the bench.
+# `check-plan` needs no bench, runs no firmware and models no electrical
+# behaviour, so it establishes nothing electrical; what it checks is that the
+# plans themselves are loadable, and the cheapest place to find a broken plan
+# is here while the most expensive is the bench.
 #
 # What the runner has to provide before this pipeline can run at all is in
 # docs/ci-examples.md. Nothing here installs Agentic HIL on the bench, writes a
@@ -29,19 +30,19 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 stages:
-  - simulate
+  - check-plan
   - hardware
 
 variables:
   # The exact release this pipeline is written against. The hardware job holds
   # the bench's own installation to it and stops when they disagree; the
-  # simulator job installs exactly it. No range, no `latest`, no git reference:
+  # check-plan job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
   AGENTIC_HIL_VERSION: "0.21.5"
 
-simulator:
-  stage: simulate
+check-plan:
+  stage: check-plan
   # No `image:` here on purpose. A runner with the docker executor has a
   # default image configured and a shell runner has none to give; either way
   # the image belongs to whoever runs the runner. If you do set one, pin it by

--- a/src/agentic_hil/cli.py
+++ b/src/agentic_hil/cli.py
@@ -525,8 +525,8 @@ def build_parser() -> argparse.ArgumentParser:
             "the bench would apply, so a plan this accepts is one the reactor can load. Where this workspace has a "
             "configuration, it also reports which device names a plan uses that the configuration does not declare, "
             "which is the other thing the bench refuses a plan for; where it has none, it says so and checks "
-            "loadability alone. Exit is nonzero if any plan is refused. This is the pre-flight check a hosted "
-            "simulator job runs; a schema-only reader passes plans the reactor then refuses"
+            "loadability alone. Exit is nonzero if any plan is refused. This is the pre-flight check a board-free CI "
+            "job runs; a schema-only reader passes plans the reactor then refuses"
         ),
     )
     check_plan_parser.add_argument("plans", nargs="+", metavar="PLAN", help="one or more test plan paths inside this workspace")
@@ -3476,7 +3476,7 @@ test_schema.__test__ = False  # type: ignore[attr-defined] - keep pytest from co
 def check_plan(plans: list[str], *, strict: bool = False) -> JsonObject:
     """Load each plan through the reactor's own loader and report whether it holds.
 
-    The hosted simulator job's one job is to establish that every plan in the
+    The board-free CI job's one job is to establish that every plan in the
     repository is one the reactor can load, and a schema-only reader cannot: it
     ignores `x-since-version`, so a plan using a key from a later plan version
     passes it and is then refused on the bench; and `yaml.safe_load` silently
@@ -3485,8 +3485,8 @@ def check_plan(plans: list[str], *, strict: bool = False) -> JsonObject:
     the whole of that guarantee: the duplicate-key rejection, the non-finite
     number rejection, the plan-version supersession and the feature gates, in one
     place rather than reimplemented in a workflow. It touches no hardware; the
-    workspace is this working directory, which is the checkout the simulator runs
-    in and the root a plan must stay inside.
+    workspace is this working directory, which is the checkout that job runs in
+    and the root a plan must stay inside.
 
     Where this workspace has a configuration, the check goes one step further and
     says which device names a plan uses that the configuration does not declare.
@@ -3500,7 +3500,7 @@ def check_plan(plans: list[str], *, strict: bool = False) -> JsonObject:
 
     Where there is no configuration, nothing is compared and the result says so.
     A plan is checked for loadability exactly as before, which is what a hosted
-    simulator with no bench at all can establish.
+    job with no bench at all can establish.
 
     A red plan does not stop the ones after it: every plan is reported, so one
     run names all of them rather than the first to fail, and `ok` is false when
@@ -3594,8 +3594,8 @@ def _configuration_unreadable(configuration: JsonObject) -> bool:
     """Whether a configuration is present but could not be loaded.
 
     True for every configuration-loading failure except `config_file_not_found`,
-    which is the one this command tolerates as the hosted-simulator case with no
-    bench at all. A malformed, unreadable, noncanonical or wrong-workspace file is
+    which is the one this command tolerates as the board-free case with no bench
+    at all. A malformed, unreadable, noncanonical or wrong-workspace file is
     a bench whose configuration is broken, and strict plan checking fails on it
     (round 1, finding 2).
     """

--- a/tests/test_ci_examples.py
+++ b/tests/test_ci_examples.py
@@ -177,9 +177,9 @@ GITLAB = load(GITLAB_EXAMPLE)
 
 def test_both_examples_parse_into_the_jobs_they_promise() -> None:
     """Two paths, in one file each, so a reader sees the split without hunting."""
-    assert set(GITHUB["jobs"]) == {"hardware", "simulator"}
-    assert {"hardware", "simulator"} <= set(GITLAB)
-    assert GITLAB["stages"] == ["simulate", "hardware"]
+    assert set(GITHUB["jobs"]) == {"hardware", "check-plan"}
+    assert {"hardware", "check-plan"} <= set(GITLAB)
+    assert GITLAB["stages"] == ["check-plan", "hardware"]
 
 
 def test_the_pinned_version_is_the_release_the_examples_are_written_for() -> None:
@@ -263,7 +263,7 @@ def test_the_gitlab_hardware_job_reaches_the_bench_only_through_its_tags() -> No
     job = GITLAB["hardware"]
 
     assert job["tags"] == [BENCH_LABEL, BOARD_LABEL]
-    assert "tags" not in GITLAB["simulator"]
+    assert "tags" not in GITLAB["check-plan"]
 
 
 def test_the_gitlab_hardware_job_refuses_every_untrusted_source() -> None:
@@ -367,23 +367,23 @@ def test_the_evidence_is_uploaded_whatever_the_run_did() -> None:
     assert artifacts["reports"]["junit"].startswith("artifacts/junit-")
 
 
-def test_the_simulator_job_is_the_hosted_path_and_touches_no_bench() -> None:
+def test_the_check_plan_job_is_the_board_free_path_and_touches_no_bench() -> None:
     """The other half of the file: no board, so any runner, and a real check.
 
     The check is `check-plan`, which loads each plan through the reactor's own
     loader, not a schema-only reader that would pass a plan the reactor then
     refuses. And it is never `test-reactor`, which drives the board.
     """
-    simulator = GITHUB["jobs"]["simulator"]
+    board_free = GITHUB["jobs"]["check-plan"]
 
-    assert "self-hosted" not in simulator["runs-on"]
-    assert "concurrency" not in simulator
-    installed = " ".join(github_commands(GITHUB, "simulator"))
+    assert "self-hosted" not in board_free["runs-on"]
+    assert "concurrency" not in board_free
+    installed = " ".join(github_commands(GITHUB, "check-plan"))
     assert "agentic-hil check-plan" in installed
     assert "agentic-hil test-reactor" not in installed
-    gitlab_simulator = " ".join(gitlab_commands(GITLAB, "simulator"))
-    assert "agentic-hil check-plan" in gitlab_simulator
-    assert "agentic-hil test-reactor" not in gitlab_simulator
+    gitlab_board_free = " ".join(gitlab_commands(GITLAB, "check-plan"))
+    assert "agentic-hil check-plan" in gitlab_board_free
+    assert "agentic-hil test-reactor" not in gitlab_board_free
 
 
 def test_every_command_the_examples_invoke_is_one_this_build_defines() -> None:
@@ -415,9 +415,9 @@ def test_every_command_the_examples_invoke_is_one_this_build_defines() -> None:
     invoked = invoked_subcommands(
         [
             *github_commands(GITHUB, "hardware"),
-            *github_commands(GITHUB, "simulator"),
+            *github_commands(GITHUB, "check-plan"),
             *gitlab_commands(GITLAB, "hardware"),
-            *gitlab_commands(GITLAB, "simulator"),
+            *gitlab_commands(GITLAB, "check-plan"),
         ]
     )
 
@@ -464,9 +464,9 @@ def test_no_step_in_either_example_downloads_something_unpinned() -> None:
     """A bench executes what these lines say. Nothing here is decided by a clock."""
     commands = [
         *github_commands(GITHUB, "hardware"),
-        *github_commands(GITHUB, "simulator"),
+        *github_commands(GITHUB, "check-plan"),
         *gitlab_commands(GITLAB, "hardware"),
-        *gitlab_commands(GITLAB, "simulator"),
+        *gitlab_commands(GITLAB, "check-plan"),
     ]
 
     assert unpinned_downloads(commands) == []

--- a/tests/test_test_reactor.py
+++ b/tests/test_test_reactor.py
@@ -1178,7 +1178,7 @@ def test_cli_returns_failure_for_audit_failed_result(monkeypatch: pytest.MonkeyP
 
 
 def test_check_plan_accepts_a_loadable_plan(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
-    """The hosted simulator's happy path: a plan the reactor can load passes,
+    """The board-free job's happy path: a plan the reactor can load passes,
     with no configuration and no hardware."""
     monkeypatch.chdir(tmp_path)
     plan = tmp_path / "nominal.testconfig.yaml"
@@ -1382,7 +1382,7 @@ def test_check_plan_without_a_configuration_says_so_and_checks_loadability(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    """The hosted simulator has no bench at all, and this is its whole job.
+    """The board-free job has no bench at all, and this is its whole job.
 
     Nothing is compared, the result says why, and a plan naming a device nobody
     declared is still reported as loading, because on a workspace with no

--- a/tests/test_verify_published_examples.py
+++ b/tests/test_verify_published_examples.py
@@ -119,9 +119,9 @@ def test_the_probed_commands_are_exactly_the_ones_the_examples_invoke() -> None:
     invoked = invoked_subcommands(
         [
             *github_commands(GITHUB, "hardware"),
-            *github_commands(GITHUB, "simulator"),
+            *github_commands(GITHUB, "check-plan"),
             *gitlab_commands(GITLAB, "hardware"),
-            *gitlab_commands(GITLAB, "simulator"),
+            *gitlab_commands(GITLAB, "check-plan"),
         ]
     )
 


### PR DESCRIPTION
The hosted job in the shipped CI examples was named `simulator`, and `check-plan`'s help and docstrings called the hosted case a simulator. The job installs the pinned release and loads every plan through the reactor's own loader; it runs no firmware and models no electrical behaviour, and its own comments already said it establishes nothing electrical. The word promised an emulation the product has never contained.

The job is now named `check-plan` in `examples/ci/github-actions.yml` and `examples/ci/gitlab-ci.yml` (on GitLab also the stage), the header comments and `docs/ci-examples.md` state that a green run says nothing about a board and everything about the plans, and the `check-plan` help and docstrings say board-free or without a bench. Nothing a job runs, refuses, pins or uploads changes, and the command keeps every option, output field and exit code it had. The starter carries the same rename on its side.

Closes #471