### PR TITLE
Open 0.21.6 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Agentic Hardware-in-the-Loop (Agentic HIL) will be docume
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning while pre-1.0 changes may still move quickly.
 
+## [Unreleased]
+
 ## [0.21.5] - 2026-09-07
 
 ### Added

--- a/docs/ci-examples.md
+++ b/docs/ci-examples.md
@@ -71,7 +71,7 @@ Both files carry one variable, `AGENTIC_HIL_VERSION`, set to the exact release
 these examples are written for:
 
 ```yaml
-AGENTIC_HIL_VERSION: "0.21.5"
+AGENTIC_HIL_VERSION: "0.21.6"
 ```
 
 An exact version, never a range, never `latest`, and never a git reference. A

--- a/examples/ci/github-actions.yml
+++ b/examples/ci/github-actions.yml
@@ -32,7 +32,7 @@ env:
   # check-plan job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
-  AGENTIC_HIL_VERSION: "0.21.5"
+  AGENTIC_HIL_VERSION: "0.21.6"
 
 jobs:
   hardware:

--- a/examples/ci/gitlab-ci.yml
+++ b/examples/ci/gitlab-ci.yml
@@ -39,7 +39,7 @@ variables:
   # check-plan job installs exactly it. No range, no `latest`, no git reference:
   # a version a resolver picked is a version nobody reviewed, and the two jobs
   # would stop being about the same code.
-  AGENTIC_HIL_VERSION: "0.21.5"
+  AGENTIC_HIL_VERSION: "0.21.6"
 
 check-plan:
   stage: check-plan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentic-hil"
-version = "0.21.5"
+version = "0.21.6.dev0"
 description = "Hardware-in-the-loop MCP server for AI coding agents: develop firmware on the real board behind your debug probe, flashing, resetting and driving UART and CAN against it. The run on the hardware is the gate that decides the work is done, and a pytest plugin runs the same gate in CI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agentic_hil/__init__.py
+++ b/src/agentic_hil/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.21.5"
+__version__ = "0.21.6.dev0"
 
 if TYPE_CHECKING:
     from agentic_hil.artifacts import ArtifactManager


### PR DESCRIPTION
0.21.5 is published, so the tree moves off the number it just shipped.

The distribution version becomes `0.21.6.dev0` in `pyproject.toml` and `src/agentic_hil/__init__.py`, the CHANGELOG gets an empty Unreleased section above 0.21.5, and the three positions that state the release this tree builds toward, the two shipped CI example files and the page that documents them, move to 0.21.6. Every other position keeps naming 0.21.5, which is the release that is on the index.

`python tools/check_version_consistency.py` is silent, `python tools/check_shipped_references.py` passes, ruff is clean, and the 247 tests that read a version or the changelog pass.