### PR TITLE
test: gate install.sh and agent registration in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 **
 !evals/
 !evals/**
+!pyproject.toml
+!README.md
+!LICENSE
 evals/install/artifacts/
 # The TLS-proxy eval overlays this package onto a released install, so its
 # container build needs the source under review in the context. Nothing else
@@ -8,6 +11,7 @@ evals/install/artifacts/
 !src/
 !src/agentic_hil/
 !src/agentic_hil/**
+**/*.egg-info/
 # And the installer under review, so the same eval can run the file this
 # working tree would publish instead of only the one already published.
 !install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,30 @@ jobs:
           python -m pip install pip-audit
           pip-audit
 
+  agent-registration:
+    name: Agent registration (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify Codex and Claude Code registration with real CLIs
+        run: python tools/test_agent_registration.py
+
+      - name: Upload registration gate evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: agent-registration-gate
+          path: evals/install/artifacts/registration-gate/
+          if-no-files-found: error
+
   required-ci:
     name: Required CI
     runs-on: ubuntu-latest
@@ -283,6 +307,7 @@ jobs:
       - container_tests
       - release_metadata
       - audit
+      - agent-registration
     if: ${{ always() }}
     steps:
       - name: Check required jobs
@@ -302,5 +327,9 @@ jobs:
           fi
           if [[ "${{ needs.audit.result }}" != "success" ]]; then
             echo "Dependency audit finished with ${{ needs.audit.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.agent-registration.result }}" != "success" ]]; then
+            echo "Agent registration gates finished with ${{ needs.agent-registration.result }}"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Verify Codex and Claude Code registration with real CLIs
+      - name: Verify install.sh and Codex/Claude Code registration with real CLIs
         run: python tools/test_agent_registration.py
 
       - name: Upload registration gate evidence

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,6 +35,7 @@ exclude tests/test_release_requirements.py
 exclude tests/test_shipped_profiles.py
 exclude tests/test_verify_published_examples.py
 exclude tests/test_ci_linux.py
+exclude tests/test_agent_registration_gate.py
 # The battery is `tools/bench_battery.py`, so its test imports out of the same
 # directory and cannot collect from a distribution that does not carry it.
 exclude tests/test_bench_battery.py

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -1,5 +1,8 @@
 # LLM installation evaluation
 
+For deterministic, login-free Codex and Claude Code registration tests required
+by CI, see [Docker registration gates](REGISTRATION_GATES.md).
+
 This evaluator measures whether a selected **agent CLI and model** can follow
 the Agentic HIL installation guide in a clean environment. Agent CLI and model
 are independent matrix axes.

--- a/evals/install/README.md
+++ b/evals/install/README.md
@@ -1,6 +1,6 @@
 # LLM installation evaluation
 
-For deterministic, login-free Codex and Claude Code registration tests required
+For login-free installation-script and Codex/Claude Code registration tests required
 by CI, see [Docker registration gates](REGISTRATION_GATES.md).
 
 This evaluator measures whether a selected **agent CLI and model** can follow

--- a/evals/install/REGISTRATION_GATES.md
+++ b/evals/install/REGISTRATION_GATES.md
@@ -6,13 +6,28 @@ Run from the repository with a Linux Docker engine:
 python tools/test_agent_registration.py
 ```
 
-The image builds a wheel from the **current working tree**, including uncommitted
-changes, and uses the real Codex and Claude Code CLIs from the existing npm lock.
-Each case starts with a fresh home and installs that wheel through pipx. Tests
-run as an ordinary user with networking disabled, no credentials, no host mounts
-and no hardware. Only the image build needs network access.
+Both mandatory stages use the real Codex and Claude Code CLIs from the existing
+npm lock, ordinary container users, fresh homes, no credentials, no host mounts
+and no hardware. Docker builds have network access. Runtime networking differs
+between the two stages:
 
-Both agents must pass all eight cases:
+- **Script installation (network enabled):** the container starts without
+  Agentic HIL, uv, pipx, prepared wheels or a package cache. It runs the current
+  checkout's unmodified `install.sh`, which bootstraps uv and downloads the
+  published Agentic HIL package and its default `[can]` extra from PyPI. Four
+  cases cover `sh install.sh --agent codex`, `sh install.sh --agent claude-code`
+  and automatic agent detection without `--agent`, checked for both clients.
+  The harness then checks what the script registered; it never invokes
+  `agent-install` or `setup` to repair a missing script registration. The report
+  records the installed release and the exact installer SHA-256 and rejects a
+  script that differs from the checkout. Network/download failures fail the gate.
+- **Current wheel (network disabled):** an image builds the **current working
+  tree**, including uncommitted changes, into a wheel. Each case installs it
+  through pipx from the prepared wheel directory, then checks the current
+  implementation. This stage covers changes not yet available from PyPI.
+
+Both stages must pass: **20 cases total**, with no switch to omit either stage.
+The wheel stage requires all eight cases for each agent:
 
 | Case | Required evidence |
 | --- | --- |
@@ -25,20 +40,26 @@ Both agents must pass all eight cases:
 | Missing registration control | After a successful install, removing the entry makes verification fail |
 | Broken launcher control | A still-present launcher that exits zero without serving MCP makes verification fail |
 
-Positive cases verify the installed skill against the wheel's bundled contents
-and check the user-level configuration. Development packages may carry the last
-released skill version; the installed skill must still match the wheel exactly.
+Positive cases verify the installed skill against the distribution's bundled
+contents and check the user-level configuration. Development packages may carry
+the last released skill version; the installed skill must still match the
+distribution exactly.
 Codex must report an enabled entry; Claude must report a **connected user-scope**
 entry. The exact registered command must also answer an MCP initialization,
-the complete committed `tools.list.expected` contract with annotations, and a
+the complete tool contract with annotations, and a
 `project_config_describe` call. A second, unconfigured project must expose MCP
 and answer `config_file_not_found`, proving registration is independent of
-project setup.
+project setup. The wheel stage uses the committed `tools.list.expected`; the
+script stage checks against the installed published distribution's declaration
+and requires the core configuration, debugger and flashing tools. A future
+development tool therefore need not already exist on PyPI for the script to pass.
 
 Docker absence, build/startup failures, timeouts, missing/duplicate reports,
-missing cases and skipped cases all fail. `report.json`, `build.log` and
-`container.log` are written under `evals/install/artifacts/registration-gate/`
-(override with `--output`). A failed rerun replaces any old passing report.
+missing cases and skipped cases all fail. `report.json`, `script-build.log`,
+`script-container.log`, `wheel-build.log` and `wheel-container.log` are written
+under `evals/install/artifacts/registration-gate/` (override with `--output`). The
+script log includes install.sh's actual transcript. A failed rerun replaces any
+old passing report.
 
 The **Agent registration (Docker)** job runs on every CI push/PR without a path
 filter and feeds **Required CI**. Skipped, cancelled and failed registration jobs

--- a/evals/install/REGISTRATION_GATES.md
+++ b/evals/install/REGISTRATION_GATES.md
@@ -1,0 +1,51 @@
+# Docker registration gates
+
+Run from the repository with a Linux Docker engine:
+
+```console
+python tools/test_agent_registration.py
+```
+
+The image builds a wheel from the **current working tree**, including uncommitted
+changes, and uses the real Codex and Claude Code CLIs from the existing npm lock.
+Each case starts with a fresh home and installs that wheel through pipx. Tests
+run as an ordinary user with networking disabled, no credentials, no host mounts
+and no hardware. Only the image build needs network access.
+
+Both agents must pass all eight cases:
+
+| Case | Required evidence |
+| --- | --- |
+| Fresh installation | `agent-install` succeeds; actual CLI `mcp get` and `mcp list` find the entry in two projects |
+| Existing settings and repeat | Other settings and MCP entries survive; running the installer twice changes no registered files |
+| First project setup | `setup` succeeds without attached hardware and retains the user integration |
+| Refused project configuration | `setup` fails, reports separate scope results, and keeps the working user integration |
+| Invalid client configuration | Nonzero exit, exact refusal, unchanged original bytes, no partial skill |
+| Operator-owned conflicting entry | Nonzero exit, unchanged operator entry and complete rollback |
+| Missing registration control | After a successful install, removing the entry makes verification fail |
+| Broken launcher control | A still-present launcher that exits zero without serving MCP makes verification fail |
+
+Positive cases verify the installed skill against the wheel's bundled contents
+and check the user-level configuration. Development packages may carry the last
+released skill version; the installed skill must still match the wheel exactly.
+Codex must report an enabled entry; Claude must report a **connected user-scope**
+entry. The exact registered command must also answer an MCP initialization,
+the complete committed `tools.list.expected` contract with annotations, and a
+`project_config_describe` call. A second, unconfigured project must expose MCP
+and answer `config_file_not_found`, proving registration is independent of
+project setup.
+
+Docker absence, build/startup failures, timeouts, missing/duplicate reports,
+missing cases and skipped cases all fail. `report.json`, `build.log` and
+`container.log` are written under `evals/install/artifacts/registration-gate/`
+(override with `--output`). A failed rerun replaces any old passing report.
+
+The **Agent registration (Docker)** job runs on every CI push/PR without a path
+filter and feeds **Required CI**. Skipped, cancelled and failed registration jobs
+make that aggregate fail. Repository branch protection must require **Required
+CI** to prevent merges; workflow code alone cannot enable branch protection.
+
+This gate tests Linux CLI integration without model calls. It does not prove
+that an already running desktop session reloads its configuration, that a model
+chooses a tool, or that Windows-specific paths behave identically. The existing
+model-driven installation evaluation covers agent behavior separately.

--- a/evals/install/container/Dockerfile
+++ b/evals/install/container/Dockerfile
@@ -120,7 +120,23 @@ USER eval
 WORKDIR /workspace
 ENTRYPOINT ["/usr/bin/python3", "-m", "evals.install.container_entrypoint"]
 
-# Deterministic registration gate: the same locked real CLIs, no model/login.
+# Script installation starts with agent CLIs and system Python, but without
+# Agentic HIL, uv, pipx, a tool cache or prepared package wheels. install.sh
+# downloads and installs the published package during the test run itself.
+FROM agent-clis AS script-registration-gate
+RUN useradd --create-home --user-group --shell /bin/bash eval
+COPY evals /opt/evals
+COPY install.sh /opt/registration/install.sh
+ENV HOME=/home/eval \
+    USERPROFILE=/home/eval \
+    PYTHONPATH=/opt \
+    DISABLE_AUTOUPDATER=1 \
+    PATH=/opt/agent-clis/node_modules/.bin:/usr/local/bin:/usr/bin:/bin
+USER eval
+WORKDIR /home/eval
+ENTRYPOINT ["/usr/bin/python3", "-m", "evals.install.registration_gate", "--mode", "script"]
+
+# Current-source registration gate: the same locked real CLIs, no model/login.
 # Build the working tree into a wheel; runtime installation is user-local and
 # offline. The source is never on the installed server's import path.
 FROM agent-clis AS registration-gate

--- a/evals/install/container/Dockerfile
+++ b/evals/install/container/Dockerfile
@@ -1,7 +1,7 @@
 # Pinned by digest, not by tag: a tag is a moving target, and an eval that
 # silently changes its base image is an eval whose results cannot be compared
 # across runs. Dependabot's docker ecosystem keeps the digest fresh.
-FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS agent-clis
 
 # make is here for the tempting workspace fixture: a firmware repository offers
 # "make flash", and a path around the gate that cannot run is no temptation.
@@ -27,6 +27,7 @@ RUN cd /opt/agent-clis \
     && npm ci \
     && npm cache clean --force
 
+FROM agent-clis AS install-eval
 RUN useradd --create-home --user-group --shell /bin/bash eval \
     && install -d -o eval -g eval /workspace \
     && touch /job.json
@@ -118,3 +119,31 @@ ENV HOME=/home/eval \
 USER eval
 WORKDIR /workspace
 ENTRYPOINT ["/usr/bin/python3", "-m", "evals.install.container_entrypoint"]
+
+# Deterministic registration gate: the same locked real CLIs, no model/login.
+# Build the working tree into a wheel; runtime installation is user-local and
+# offline. The source is never on the installed server's import path.
+FROM agent-clis AS registration-gate
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pipx \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --user-group --shell /bin/bash eval
+COPY evals /opt/evals
+COPY pyproject.toml README.md LICENSE /opt/registration-source/
+COPY src /opt/registration-source/src
+RUN /opt/install-eval-verifier/bin/pip wheel --no-deps \
+        --wheel-dir /opt/registration-wheels /opt/registration-source \
+    && /opt/install-eval-verifier/bin/pip download --require-hashes \
+        -r /opt/evals/install/container/requirements.txt --dest /opt/registration-wheels \
+    && rm -rf /opt/registration-source
+ENV HOME=/home/eval \
+    USERPROFILE=/home/eval \
+    PYTHONPATH=/opt \
+    DISABLE_AUTOUPDATER=1 \
+    PATH=/opt/agent-clis/node_modules/.bin:/usr/local/bin:/usr/bin:/bin
+USER eval
+WORKDIR /home/eval
+ENTRYPOINT ["/usr/bin/python3", "-m", "evals.install.registration_gate"]
+
+# Preserve the existing evaluation image as the default build target.
+FROM install-eval AS runtime

--- a/evals/install/registration_gate.py
+++ b/evals/install/registration_gate.py
@@ -1,0 +1,280 @@
+"""Offline black-box gates against the installed wheel and actual agent CLIs.
+
+Only the registration-gate Docker target runs this module. No imports from
+agentic_hil, mocks, credentials, host homes, or hardware are involved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import traceback
+import zipfile
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:  # Host-side report tests also run on Python 3.10.
+    import tomli as tomllib
+
+AGENTS = ("codex", "claude-code")
+SCENARIOS = (
+    "fresh-install",
+    "merge-and-repeat",
+    "setup",
+    "project-refused",
+    "invalid-config",
+    "operator-conflict",
+    "missing-registration-control",
+    "broken-launcher-control",
+)
+REPORT_PREFIX = "AGENT_REGISTRATION_GATE="
+
+
+def require(condition: object, detail: str) -> None:
+    if not condition:
+        raise AssertionError(detail)
+
+
+def validate_report(report: dict) -> None:
+    """A green exit without every required case is a failure, including skips."""
+    expected = {(agent, scenario) for agent in AGENTS for scenario in SCENARIOS}
+    rows = report["cases"]
+    actual = [(row["agent"], row["scenario"]) for row in rows]
+    require(len(actual) == len(expected) and set(actual) == expected, "missing or duplicate registration cases")
+    require(all(row.get("status") == "passed" for row in rows), "failed, skipped, or unfinished registration cases")
+    require(report.get("ok") is True, "registration gate did not report success")
+    require(set(report["versions"]) == set(AGENTS), "missing actual CLI versions")
+    require(all(report["versions"].values()), "empty CLI version")
+
+
+class Case:
+    def __init__(self, agent: str, scenario: str):
+        self.agent = agent
+        self.home = Path("/home/eval/registration-cases") / agent / scenario
+        self.home.mkdir(parents=True, mode=0o700)
+        self.workspace = self.home / "firmware project"
+        self.workspace.mkdir()
+        self.other_workspace = self.home / "second project"
+        self.other_workspace.mkdir()
+        self.env = {
+            "HOME": str(self.home),
+            "USERPROFILE": str(self.home),
+            "USER": "eval",
+            "PATH": f"{self.home}/.local/bin:/opt/agent-clis/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+            "XDG_CONFIG_HOME": str(self.home / ".config"),
+            "XDG_STATE_HOME": str(self.home / ".local/state"),
+            "XDG_DATA_HOME": str(self.home / ".local/share"),
+            "XDG_CACHE_HOME": str(self.home / ".cache"),
+            "PIPX_HOME": str(self.home / ".local/share/pipx"),
+            "PIPX_BIN_DIR": str(self.home / ".local/bin"),
+            "PIP_CONFIG_FILE": "/dev/null",
+            "PIP_NO_INDEX": "1",
+            "PIP_FIND_LINKS": "/opt/registration-wheels",
+            "DISABLE_AUTOUPDATER": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "NO_COLOR": "1",
+        }
+        self.config = self.home / (".codex/config.toml" if agent == "codex" else ".claude.json")
+        self.skill = self.home / (".codex" if agent == "codex" else ".claude") / "skills/agentic-hil/SKILL.md"
+        self.launcher = self.home / ".local/bin/agentic-hil"
+        self.cli = "codex" if agent == "codex" else "claude"
+
+    def run(self, command: list[str], *, cwd: Path | None = None, input_text: str | None = None) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            command, cwd=cwd or self.workspace, env=self.env,
+            input=input_text, capture_output=True, text=True, timeout=45, check=False,
+        )
+        return result
+
+    def checked(self, command: list[str], **kwargs) -> str:
+        result = self.run(command, **kwargs)
+        require(result.returncode == 0, f"{command}: exit={result.returncode}\n{result.stdout}\n{result.stderr}")
+        return result.stdout
+
+    def install_wheel(self) -> None:
+        require(not self.config.exists() and not self.skill.exists(), "case did not start with a clean home")
+        wheels = list(Path("/opt/registration-wheels").glob("agentic_hil-*.whl"))
+        require(len(wheels) == 1, f"expected one wheel, got {wheels}")
+        with zipfile.ZipFile(wheels[0]) as wheel:
+            self.packaged_skill = wheel.read("agentic_hil/skills/agentic-hil/SKILL.md").decode("utf-8").replace("\r\n", "\n")
+        self.checked(["pipx", "install", "--pip-args=--no-index --find-links=/opt/registration-wheels", str(wheels[0])])
+        require(self.launcher.is_file() and self.launcher.resolve().is_relative_to(self.home), "launcher is not user-local")
+        self.version = self.checked([str(self.launcher), "--version"]).strip()
+        require(bool(self.version), "installed package reported no version")
+        # pip installation alone does not register the integration.
+        self.expect_missing()
+
+    def expect_missing(self) -> None:
+        result = self.run([self.cli, "mcp", "get", "agentic-hil"])
+        require(result.returncode != 0, f"CLI sees a registration that should be absent: {result.stdout}")
+        require("agentic-hil" in result.stdout + result.stderr, f"CLI failed for an unrelated reason: {result.stderr}")
+
+    def integrate(self, command: str = "agent-install", *, success: bool = True) -> dict:
+        result = self.run([str(self.launcher), command, "--agent", self.agent, "--json"])
+        document = json.loads(result.stdout)
+        require(document.get("ok") is success, f"unexpected {command} result: {document}")
+        require(result.returncode == (0 if success else 1), f"exit code contradicts {command} result: {result}")
+        return document
+
+    def config_document(self) -> dict:
+        text = self.config.read_text(encoding="utf-8")
+        return tomllib.loads(text) if self.agent == "codex" else json.loads(text)
+
+    def verify(self, *, provisioned: bool = False) -> None:
+        require(self.skill.is_file(), f"missing skill: {self.skill}")
+        skill_text = self.skill.read_text(encoding="utf-8")
+        # Development packages can carry the last released skill version. The
+        # installation must reproduce the wheel's actual skill, not invent a
+        # version string from the running CLI or accept a stale installed copy.
+        require("name: agentic-hil\n" in skill_text and skill_text == self.packaged_skill, "installed skill differs from the wheel")
+        if self.agent == "codex":
+            registration = (self.home / ".codex/AGENTS.md").read_text(encoding="utf-8")
+            require(str(self.skill) in registration, "Codex AGENTS.md does not register the installed skill")
+        key = "mcp_servers" if self.agent == "codex" else "mcpServers"
+        entry = self.config_document()[key]["agentic-hil"]
+        require(Path(entry["command"]).is_absolute(), "registration command is not absolute")
+        require(Path(entry["command"]).resolve() == self.launcher.resolve(), "registration points at the wrong launcher")
+        require(entry["args"] == ["mcp-stdio"], f"unexpected MCP arguments: {entry}")
+        require(not set(entry) & {"cwd", "env", "url"}, f"registration is bound to one project or environment: {entry}")
+
+        # A fresh CLI process in BOTH projects must discover the user entry.
+        for workspace in (self.workspace, self.other_workspace):
+            if self.agent == "codex":
+                got = json.loads(self.checked(["codex", "mcp", "get", "agentic-hil", "--json"], cwd=workspace))
+                listed = json.loads(self.checked(["codex", "mcp", "list", "--json"], cwd=workspace))
+                require(got["name"] == "agentic-hil" and got["enabled"] is True, f"Codex registration disabled: {got}")
+                require(got["transport"]["command"] == entry["command"], f"Codex loads a different command: {got}")
+                require(got["transport"]["args"] == entry["args"], f"Codex loads different arguments: {got}")
+                require(sum(item["name"] == "agentic-hil" and item["enabled"] is True for item in listed) == 1, f"Codex list: {listed}")
+            else:
+                got = self.checked(["claude", "mcp", "get", "agentic-hil"], cwd=workspace)
+                require("Scope: User" in got and "Connected" in got, f"Claude has no connected user registration: {got}")
+                require(f"Command: {entry['command']}" in got and "Args: mcp-stdio" in got, f"Claude loads another command: {got}")
+                listed = self.checked(["claude", "mcp", "list"], cwd=workspace)
+                require(any(line.startswith("agentic-hil:") and "Connected" in line for line in listed.splitlines()), f"Claude list: {listed}")
+            self.probe([entry["command"], *entry["args"]], workspace, provisioned and workspace == self.workspace)
+            require(not (workspace / ".mcp.json").exists(), "registration leaked into firmware project")
+            require(not (workspace / ".agentic-hil/config.yaml").exists(), "authoritative config leaked into firmware project")
+
+    def probe(self, command: list[str], cwd: Path, provisioned: bool) -> None:
+        messages = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+                "protocolVersion": "2025-06-18", "capabilities": {},
+                "clientInfo": {"name": "registration-gate", "version": "1"},
+            }},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "project_config_describe", "arguments": {}}},
+        ]
+        output = self.checked(command, cwd=cwd, input_text="".join(json.dumps(message) + "\n" for message in messages))
+        responses = [json.loads(line) for line in output.splitlines()]
+        require([item.get("id") for item in responses] == [1, 2, 3], f"incomplete MCP exchange: {output}")
+        require(responses[0]["result"]["serverInfo"] == {"name": "agentic-hil", "version": self.version}, "wrong MCP server identity")
+        tools = responses[1]["result"]["tools"]
+        expected = (Path(__file__).with_name("tools.list.expected")).read_text().splitlines()
+        require(sorted(tool["name"] for tool in tools) == expected, "MCP tools/list does not match the shipped contract")
+        require(all(tool.get("annotations", {}).get("title") for tool in tools), "MCP tools lack annotations")
+        result = responses[2]["result"]
+        if provisioned:
+            require(result["isError"] is False and result["structuredContent"]["ok"] is True, f"configured server failed: {result}")
+        else:
+            require(result["isError"] is True and result["structuredContent"]["error_type"] == "config_file_not_found", f"wrong unconfigured-server response: {result}")
+
+    def seed(self, conflict: bool = False) -> None:
+        self.config.parent.mkdir(parents=True, exist_ok=True)
+        name = "agentic-hil" if conflict else "operator-tool"
+        if self.agent == "codex":
+            text = f'# operator comment\nmodel = "operator-model"\n[mcp_servers.{name}]\ncommand = "/usr/bin/true"\nargs = []\nenabled = false\n'
+        else:
+            text = json.dumps({"theme": "dark", "mcpServers": {name: {"type": "stdio", "command": "/usr/bin/true", "args": []}}}) + "\n"
+        self.config.write_text(text, encoding="utf-8")
+
+    def exercise(self, scenario: str) -> None:
+        self.install_wheel()
+        if scenario in {"invalid-config", "operator-conflict"}:
+            if scenario == "invalid-config":
+                self.config.parent.mkdir(parents=True, exist_ok=True)
+                self.config.write_text("[broken", encoding="utf-8")
+            else:
+                self.seed(conflict=True)
+            before = self.config.read_bytes()
+            result = self.integrate(success=False)
+            expected = "config_invalid" if scenario == "invalid-config" else "mcp_config_conflict"
+            require(result["steps"]["mcp_config"]["error_type"] == expected, f"wrong refusal: {result}")
+            require(result["rollback"]["attempted"] is True and result["rollback"]["ok"] is True, f"rollback failed: {result}")
+            require(self.config.read_bytes() == before and not self.skill.exists(), "refusal modified operator config or left a partial skill")
+            return
+        if scenario == "merge-and-repeat":
+            self.seed()
+            before = self.config_document()
+        if scenario == "project-refused":
+            # A relative override is refused before discovery, without a device.
+            self.env["AGENTIC_HIL_CONFIG"] = "relative-policy.yaml"
+            result = self.integrate("setup", success=False)
+            require(result["scopes"]["user"]["ok"] is True and result["scopes"]["project"]["ok"] is False, f"project failure removed user integration: {result}")
+            del self.env["AGENTIC_HIL_CONFIG"]
+        else:
+            result = self.integrate("setup" if scenario == "setup" else "agent-install")
+        if scenario == "merge-and-repeat":
+            # Check before starting the client: Claude migrates preferences
+            # (including theme) out of .claude.json during its own startup.
+            after = self.config_document()
+            key = "mcp_servers" if self.agent == "codex" else "mcpServers"
+            del after[key]["agentic-hil"]
+            require(after == before, "registration changed unrelated operator settings")
+            if self.agent == "codex":
+                require("# operator comment\n" in self.config.read_text(), "registration removed operator comment")
+            snapshot = {path: path.read_bytes() for path in (self.config, self.skill)}
+            self.integrate()
+            require(all(path.read_bytes() == content for path, content in snapshot.items()), "repeat install changed registered files")
+        self.verify(provisioned=scenario == "setup")
+        if scenario.endswith("-control"):
+            if scenario == "missing-registration-control":
+                self.config.unlink()
+                self.expect_missing()
+            else:
+                # Keep the registered path present and executable with exit 0.
+                # Only the native health check/wire exchange detects this fault.
+                self.launcher.resolve().write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            try:
+                self.verify()
+            except (AssertionError, KeyError, FileNotFoundError):
+                return
+            raise AssertionError(f"negative control went green: {scenario}")
+
+
+def main() -> int:
+    require(sys.platform == "linux" and os.getuid() != 0, "registration gate requires its non-root Linux container")
+    versions = {}
+    pins = json.loads(Path("/opt/agent-clis/package.json").read_text())["dependencies"]
+    for agent, package in (("codex", "@openai/codex"), ("claude-code", "@anthropic-ai/claude-code")):
+        cli = "/opt/agent-clis/node_modules/.bin/" + ("codex" if agent == "codex" else "claude")
+        result = subprocess.run([cli, "--version"], capture_output=True, text=True, timeout=30, check=True)
+        versions[agent] = result.stdout.strip()
+        require(re.search(rf"(?<![\d.]){re.escape(pins[package])}(?![\d.])", result.stdout), f"CLI version differs from lock: {result.stdout}")
+    rows = []
+    for agent in AGENTS:
+        for scenario in SCENARIOS:
+            started = time.monotonic()
+            row = {"agent": agent, "scenario": scenario, "status": "failed"}
+            try:
+                Case(agent, scenario).exercise(scenario)
+                row["status"] = "passed"
+            except Exception:
+                row["detail"] = traceback.format_exc()
+            row["seconds"] = round(time.monotonic() - started, 2)
+            rows.append(row)
+            print(json.dumps(row), flush=True)
+    report = {"ok": all(row["status"] == "passed" for row in rows), "versions": versions, "cases": rows}
+    print(REPORT_PREFIX + json.dumps(report), flush=True)
+    validate_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/install/registration_gate.py
+++ b/evals/install/registration_gate.py
@@ -1,14 +1,19 @@
-"""Offline black-box gates against the installed wheel and actual agent CLIs.
+"""Black-box registration gates for install.sh and the current source wheel.
 
-Only the registration-gate Docker target runs this module. No imports from
-agentic_hil, mocks, credentials, host homes, or hardware are involved.
+The script target downloads the published package through the real installer;
+the wheel target checks the current source offline. Neither receives credentials,
+host homes, or hardware, and neither mocks an agent CLI or repairs a script's
+registration before checking it.
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -22,7 +27,7 @@ except ImportError:  # Host-side report tests also run on Python 3.10.
     import tomli as tomllib
 
 AGENTS = ("codex", "claude-code")
-SCENARIOS = (
+WHEEL_SCENARIOS = (
     "fresh-install",
     "merge-and-repeat",
     "setup",
@@ -32,6 +37,9 @@ SCENARIOS = (
     "missing-registration-control",
     "broken-launcher-control",
 )
+SCRIPT_SCENARIOS = ("script-explicit-agent", "script-auto-detect")
+SCENARIOS = WHEEL_SCENARIOS + SCRIPT_SCENARIOS
+SCENARIOS_BY_MODE = {"wheel": WHEEL_SCENARIOS, "script": SCRIPT_SCENARIOS, "all": SCENARIOS}
 REPORT_PREFIX = "AGENT_REGISTRATION_GATE="
 
 
@@ -40,9 +48,10 @@ def require(condition: object, detail: str) -> None:
         raise AssertionError(detail)
 
 
-def validate_report(report: dict) -> None:
+def validate_report(report: dict, *, mode: str = "all") -> None:
     """A green exit without every required case is a failure, including skips."""
-    expected = {(agent, scenario) for agent in AGENTS for scenario in SCENARIOS}
+    require(report.get("mode") == mode, f"expected {mode} registration evidence")
+    expected = {(agent, scenario) for agent in AGENTS for scenario in SCENARIOS_BY_MODE[mode]}
     rows = report["cases"]
     actual = [(row["agent"], row["scenario"]) for row in rows]
     require(len(actual) == len(expected) and set(actual) == expected, "missing or duplicate registration cases")
@@ -83,11 +92,12 @@ class Case:
         self.skill = self.home / (".codex" if agent == "codex" else ".claude") / "skills/agentic-hil/SKILL.md"
         self.launcher = self.home / ".local/bin/agentic-hil"
         self.cli = "codex" if agent == "codex" else "claude"
+        self.expected_tools = Path(__file__).with_name("tools.list.expected").read_text().splitlines()
 
-    def run(self, command: list[str], *, cwd: Path | None = None, input_text: str | None = None) -> subprocess.CompletedProcess:
+    def run(self, command: list[str], *, cwd: Path | None = None, input_text: str | None = None, timeout_s: int = 45) -> subprocess.CompletedProcess:
         result = subprocess.run(
             command, cwd=cwd or self.workspace, env=self.env,
-            input=input_text, capture_output=True, text=True, timeout=45, check=False,
+            input=input_text, capture_output=True, text=True, timeout=timeout_s, check=False,
         )
         return result
 
@@ -176,8 +186,7 @@ class Case:
         require([item.get("id") for item in responses] == [1, 2, 3], f"incomplete MCP exchange: {output}")
         require(responses[0]["result"]["serverInfo"] == {"name": "agentic-hil", "version": self.version}, "wrong MCP server identity")
         tools = responses[1]["result"]["tools"]
-        expected = (Path(__file__).with_name("tools.list.expected")).read_text().splitlines()
-        require(sorted(tool["name"] for tool in tools) == expected, "MCP tools/list does not match the shipped contract")
+        require(sorted(tool["name"] for tool in tools) == self.expected_tools, "MCP tools/list does not match the shipped contract")
         require(all(tool.get("annotations", {}).get("title") for tool in tools), "MCP tools lack annotations")
         result = responses[2]["result"]
         if provisioned:
@@ -195,6 +204,7 @@ class Case:
         self.config.write_text(text, encoding="utf-8")
 
     def exercise(self, scenario: str) -> None:
+        require(scenario in WHEEL_SCENARIOS, f"not a wheel scenario: {scenario}")
         self.install_wheel()
         if scenario in {"invalid-config", "operator-conflict"}:
             if scenario == "invalid-config":
@@ -248,7 +258,57 @@ class Case:
             raise AssertionError(f"negative control went green: {scenario}")
 
 
-def main() -> int:
+class ScriptCase(Case):
+    """The only installer here is the repository's unmodified install.sh."""
+
+    def exercise(self, scenario: str) -> None:
+        require(scenario in SCRIPT_SCENARIOS, f"not a script scenario: {scenario}")
+        script = Path("/opt/registration/install.sh")
+        # Start without a package, manager, wheelhouse or package cache. The
+        # pinned uv bootstrap and PyPI download must happen inside install.sh.
+        for key in ("PIPX_HOME", "PIPX_BIN_DIR", "PIP_NO_INDEX", "PIP_FIND_LINKS"):
+            self.env.pop(key)
+        for command in ("agentic-hil", "uv", "pipx"):
+            require(shutil.which(command, path=self.env["PATH"]) is None, f"{command} was preinstalled")
+        require(not Path("/opt/registration-wheels").exists(), "script test received prebuilt package wheels")
+        require(not self.config.exists() and not self.skill.exists(), "script test did not start clean")
+        self.expect_missing()
+        command = ["sh", str(script)]
+        if scenario == "script-explicit-agent":
+            command.extend(["--agent", self.agent])
+        result = self.run(command, timeout_s=300)
+        print(f"install.sh ({self.agent}, {scenario}):\n{result.stdout}{result.stderr}", flush=True)
+        require(result.returncode == 0, f"install.sh failed with exit {result.returncode}: {result.stdout}\n{result.stderr}")
+        require(self.launcher.is_file() and self.launcher.resolve().is_relative_to(self.home), "install.sh did not install a user-local launcher")
+        self.version = self.checked([str(self.launcher), "--version"]).strip()
+        release = re.search(r'^RELEASE="(\d+)\.(\d+)\.(\d+)"$', script.read_text(), re.MULTILINE)
+        installed = re.match(r"^(\d+)\.(\d+)\.(\d+)", self.version)
+        require(release is not None and installed is not None, "script or installed package did not report a version")
+        require(tuple(map(int, installed.groups())) >= tuple(map(int, release.groups())), "install.sh installed below its release floor")
+        # Read the installed distribution's declaration through its interpreter.
+        # The release downloaded by install.sh need not have the development
+        # checkout's tool list or skill version. This does not register anything.
+        interpreter = self.home / ".local/share/uv/tools/agentic-hil/bin/python"
+        metadata = json.loads(self.checked([str(interpreter), "-c", (
+            "import json; from importlib.metadata import distribution; "
+            "from agentic_hil.contracts import MCP_TOOL_NAMES; "
+            "d = distribution('agentic-hil'); "
+            "s = d.locate_file('agentic_hil/skills/agentic-hil/SKILL.md'); "
+            "print(json.dumps({'skill': s.read_text(), 'tools': sorted(MCP_TOOL_NAMES), 'version': d.version}))"
+        )]))
+        require(metadata["version"] == self.version, "script launcher and installed distribution disagree")
+        self.packaged_skill = metadata["skill"]
+        self.expected_tools = metadata["tools"]
+        require({"project_config_create", "project_config_describe", "debugger_info", "flash_firmware"} <= set(self.expected_tools), "published package lacks core MCP tools")
+        # No agent-install/setup call from the harness: the script must have
+        # created the integration itself before either real CLI checks it.
+        self.verify()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("wheel", "script"), default="wheel")
+    mode = parser.parse_args(argv).mode
     require(sys.platform == "linux" and os.getuid() != 0, "registration gate requires its non-root Linux container")
     versions = {}
     pins = json.loads(Path("/opt/agent-clis/package.json").read_text())["dependencies"]
@@ -259,20 +319,24 @@ def main() -> int:
         require(re.search(rf"(?<![\d.]){re.escape(pins[package])}(?![\d.])", result.stdout), f"CLI version differs from lock: {result.stdout}")
     rows = []
     for agent in AGENTS:
-        for scenario in SCENARIOS:
+        for scenario in SCENARIOS_BY_MODE[mode]:
             started = time.monotonic()
             row = {"agent": agent, "scenario": scenario, "status": "failed"}
             try:
-                Case(agent, scenario).exercise(scenario)
+                case = (ScriptCase if mode == "script" else Case)(agent, scenario)
+                case.exercise(scenario)
+                row["package_version"] = case.version
+                if mode == "script":
+                    row["installer_sha256"] = hashlib.sha256(Path("/opt/registration/install.sh").read_bytes()).hexdigest()
                 row["status"] = "passed"
             except Exception:
                 row["detail"] = traceback.format_exc()
             row["seconds"] = round(time.monotonic() - started, 2)
             rows.append(row)
             print(json.dumps(row), flush=True)
-    report = {"ok": all(row["status"] == "passed" for row in rows), "versions": versions, "cases": rows}
+    report = {"ok": all(row["status"] == "passed" for row in rows), "mode": mode, "versions": versions, "cases": rows}
     print(REPORT_PREFIX + json.dumps(report), flush=True)
-    validate_report(report)
+    validate_report(report, mode=mode)
     return 0
 
 

--- a/tests/test_agent_registration_gate.py
+++ b/tests/test_agent_registration_gate.py
@@ -1,0 +1,93 @@
+"""The Docker gate itself must fail closed on incomplete or false evidence."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from evals.install.registration_gate import AGENTS, REPORT_PREFIX, SCENARIOS
+from tools.test_agent_registration import main, read_report, run_logged
+
+
+def passing_report() -> dict:
+    return {
+        "ok": True,
+        "versions": {"codex": "codex-cli 0.145.0", "claude-code": "2.1.218 (Claude Code)"},
+        "cases": [{"agent": agent, "scenario": scenario, "status": "passed"} for agent in AGENTS for scenario in SCENARIOS],
+    }
+
+
+def test_gate_accepts_only_complete_evidence() -> None:
+    report = passing_report()
+    assert read_report("diagnostics\n" + REPORT_PREFIX + json.dumps(report) + "\n") == report
+
+
+@pytest.mark.parametrize("output", ["", "all tests passed\n", REPORT_PREFIX + "{", REPORT_PREFIX + "{}", REPORT_PREFIX + "{}\n" + REPORT_PREFIX + "{}"])
+def test_zero_exit_without_one_valid_report_is_not_success(output: str) -> None:
+    with pytest.raises((ValueError, KeyError, AssertionError)):
+        read_report(output)
+
+
+@pytest.mark.parametrize("mutation", ["empty", "missing-agent", "missing-case", "duplicate", "failed", "skipped", "unfinished", "ok-false", "no-versions"])
+def test_gate_rejects_incomplete_matrix(mutation: str) -> None:
+    report = passing_report()
+    if mutation == "empty":
+        report["cases"] = []
+    elif mutation == "missing-agent":
+        report["cases"] = [row for row in report["cases"] if row["agent"] == "codex"]
+    elif mutation == "missing-case":
+        report["cases"].pop()
+    elif mutation == "duplicate":
+        report["cases"][-1] = report["cases"][0]
+    elif mutation == "ok-false":
+        report["ok"] = False
+    elif mutation == "no-versions":
+        report["versions"] = {}
+    else:
+        report["cases"][0]["status"] = mutation
+    with pytest.raises(AssertionError):
+        read_report(REPORT_PREFIX + json.dumps(report))
+
+
+def test_missing_docker_fails_and_replaces_old_green_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "report.json").write_text(json.dumps(passing_report()), encoding="utf-8")
+    monkeypatch.setattr("tools.test_agent_registration.shutil.which", lambda _name: None)
+    assert main(["--output", str(tmp_path)]) == 1
+    assert json.loads((tmp_path / "report.json").read_text())["ok"] is False
+
+
+@pytest.mark.parametrize("exit_code", [1, 125, 137])
+def test_build_and_container_failures_cannot_pass(exit_code: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(command: list[str], **kwargs) -> subprocess.CompletedProcess:
+        kwargs["stdout"].write("container diagnostic\n")
+        return subprocess.CompletedProcess(command, exit_code)
+
+    monkeypatch.setattr("tools.test_agent_registration.subprocess.run", fail)
+    with pytest.raises(RuntimeError, match="container diagnostic"):
+        run_logged(["docker", "run", "test-image"], tmp_path / "container.log", 30)
+
+
+def test_timeout_is_not_converted_to_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def timeout(command: list[str], **kwargs) -> None:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr("tools.test_agent_registration.subprocess.run", timeout)
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_logged(["docker", "run", "test-image"], tmp_path / "container.log", 30)
+
+
+def test_required_ci_cannot_skip_registration_gate() -> None:
+    workflow = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
+    jobs = yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"]
+    gate = jobs["agent-registration"]
+    assert not gate.get("if") and not gate.get("continue-on-error")
+    checks = [step for step in gate["steps"] if step.get("run") == "python tools/test_agent_registration.py"]
+    assert len(checks) == 1 and not checks[0].get("if") and not checks[0].get("continue-on-error")
+    required = jobs["required-ci"]
+    assert "agent-registration" in required["needs"]
+    assert required["if"] == "${{ always() }}"
+    assert '"${{ needs.agent-registration.result }}" != "success"' in required["steps"][0]["run"]

--- a/tests/test_agent_registration_gate.py
+++ b/tests/test_agent_registration_gate.py
@@ -9,13 +9,14 @@ from pathlib import Path
 import pytest
 import yaml
 
-from evals.install.registration_gate import AGENTS, REPORT_PREFIX, SCENARIOS
-from tools.test_agent_registration import main, read_report, run_logged
+from evals.install.registration_gate import AGENTS, REPORT_PREFIX, SCENARIOS, SCENARIOS_BY_MODE, SCRIPT_SCENARIOS
+from tools.test_agent_registration import combine_reports, container_command, main, read_report, run_logged
 
 
 def passing_report() -> dict:
     return {
         "ok": True,
+        "mode": "all",
         "versions": {"codex": "codex-cli 0.145.0", "claude-code": "2.1.218 (Claude Code)"},
         "cases": [{"agent": agent, "scenario": scenario, "status": "passed"} for agent in AGENTS for scenario in SCENARIOS],
     }
@@ -58,6 +59,40 @@ def test_missing_docker_fails_and_replaces_old_green_report(tmp_path: Path, monk
     monkeypatch.setattr("tools.test_agent_registration.shutil.which", lambda _name: None)
     assert main(["--output", str(tmp_path)]) == 1
     assert json.loads((tmp_path / "report.json").read_text())["ok"] is False
+
+
+def stage_report(mode: str) -> dict:
+    report = passing_report()
+    report["mode"] = mode
+    report["image_id"] = f"sha256:{mode}"
+    report["cases"] = [row for row in report["cases"] if row["scenario"] in SCENARIOS_BY_MODE[mode]]
+    for row in report["cases"]:
+        if row["scenario"] in SCRIPT_SCENARIOS:
+            row["installer_sha256"] = "checkout-installer"
+    return report
+
+
+def test_combined_gate_requires_real_script_cases() -> None:
+    wheel = stage_report("wheel")
+    script = stage_report("script")
+    report = combine_reports([script, wheel], "checkout-installer")
+    assert len(report["cases"]) == 20
+    with pytest.raises(ValueError, match="both script and wheel"):
+        combine_reports([wheel], "checkout-installer")
+    with pytest.raises(AssertionError):
+        read_report(REPORT_PREFIX + json.dumps(wheel))
+
+
+def test_script_stage_must_execute_the_reviewed_installer() -> None:
+    with pytest.raises(ValueError, match="this checkout's install.sh"):
+        combine_reports([stage_report("script"), stage_report("wheel")], "different-installer")
+
+
+@pytest.mark.parametrize(("mode", "network"), [("script", "bridge"), ("wheel", "none")])
+def test_only_script_downloads_get_network_without_host_secrets(mode: str, network: str) -> None:
+    command = container_command("docker", "test-case", "sha256:tested", mode)
+    assert command[command.index("--network") + 1] == network
+    assert not {"-e", "--env", "--env-file", "-v", "--volume", "--mount", "--privileged"} & set(command)
 
 
 @pytest.mark.parametrize("exit_code", [1, 125, 137])

--- a/tools/test_agent_registration.py
+++ b/tools/test_agent_registration.py
@@ -1,0 +1,92 @@
+"""Build and run mandatory offline registration gates, including uncommitted work.
+
+Usage: python tools/test_agent_registration.py [--output DIRECTORY]
+Docker/build/startup failures, timeouts, absent reports and incomplete matrices
+all fail. No credentials or host directories are mounted into the container.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from evals.install.registration_gate import REPORT_PREFIX, validate_report  # noqa: E402
+
+
+def read_report(output: str) -> dict:
+    lines = [line.removeprefix(REPORT_PREFIX) for line in output.splitlines() if line.startswith(REPORT_PREFIX)]
+    if len(lines) != 1:
+        raise ValueError("container must emit exactly one registration gate report")
+    report = json.loads(lines[0])
+    validate_report(report)
+    return report
+
+
+def run_logged(command: list[str], path: Path, timeout: int) -> subprocess.CompletedProcess:
+    with path.open("w", encoding="utf-8") as log:
+        result = subprocess.run(command, cwd=ROOT, stdout=log, stderr=subprocess.STDOUT, text=True, timeout=timeout, check=False)
+    if result.returncode:
+        raise RuntimeError(f"command failed ({result.returncode}): {command}\n{path.read_text(encoding='utf-8')[-12000:]}")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=ROOT / "evals/install/artifacts/registration-gate")
+    args = parser.parse_args(argv)
+    args.output.mkdir(parents=True, exist_ok=True)
+    # Never leave a previous passing report beside a new failed build.
+    report_path = args.output / "report.json"
+    report_path.write_text(json.dumps({"ok": False, "error": "run has not completed"}) + "\n", encoding="utf-8")
+    docker = shutil.which("docker")
+    if docker is None:
+        print("Docker is required; registration gates cannot be skipped.", file=sys.stderr)
+        return 1
+    name = "agentic-hil-registration-" + uuid.uuid4().hex
+    try:
+        info = subprocess.run([docker, "info", "--format", "{{.OSType}}"], capture_output=True, text=True, timeout=30, check=True)
+        if info.stdout.strip() != "linux":
+            raise RuntimeError("registration gates require a Linux Docker engine")
+        with tempfile.TemporaryDirectory(prefix="agentic-hil-registration-") as temporary:
+            iidfile = Path(temporary) / "image-id"
+            print("Building the current working tree and locked agent CLIs...", flush=True)
+            run_logged([
+                docker, "build", "--target", "registration-gate", "--iidfile", str(iidfile),
+                "--file", "evals/install/container/Dockerfile", ".",
+            ], args.output / "build.log", 900)
+            image_id = iidfile.read_text().strip()
+            if not image_id.startswith("sha256:"):
+                raise RuntimeError("Docker did not produce an immutable image id")
+            print(f"Running all registration cases offline as an unprivileged user ({image_id})...", flush=True)
+            run_logged([
+                docker, "run", "--rm", "--name", name, "--network", "none",
+                "--cap-drop", "ALL", "--security-opt", "no-new-privileges",
+                "--pids-limit", "256", image_id,
+            ], args.output / "container.log", 900)
+            report = read_report((args.output / "container.log").read_text(encoding="utf-8"))
+            report["image_id"] = image_id
+            report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+            print(f"PASS: {len(report['cases'])} registration cases; {report['versions']}; report: {report_path}")
+        return 0
+    except (OSError, ValueError, KeyError, AssertionError, RuntimeError, subprocess.SubprocessError) as error:
+        report_path.write_text(json.dumps({"ok": False, "error": str(error)}, indent=2) + "\n", encoding="utf-8")
+        print(f"Registration gate FAILED: {error}", file=sys.stderr)
+        return 1
+    finally:
+        # Only our uniquely named container; this also cleans up after timeout.
+        with suppress(OSError, subprocess.SubprocessError):
+            subprocess.run([docker, "rm", "--force", name], capture_output=True, timeout=30, check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_agent_registration.py
+++ b/tools/test_agent_registration.py
@@ -1,4 +1,4 @@
-"""Build and run mandatory offline registration gates, including uncommitted work.
+"""Gate real install.sh downloads and offline registration of the current wheel.
 
 Usage: python tools/test_agent_registration.py [--output DIRECTORY]
 Docker/build/startup failures, timeouts, absent reports and incomplete matrices
@@ -8,6 +8,7 @@ all fail. No credentials or host directories are mounted into the container.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 import subprocess
@@ -20,16 +21,46 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from evals.install.registration_gate import REPORT_PREFIX, validate_report  # noqa: E402
+from evals.install.registration_gate import REPORT_PREFIX, SCRIPT_SCENARIOS, validate_report  # noqa: E402
 
 
-def read_report(output: str) -> dict:
+def read_report(output: str, *, mode: str = "all") -> dict:
     lines = [line.removeprefix(REPORT_PREFIX) for line in output.splitlines() if line.startswith(REPORT_PREFIX)]
     if len(lines) != 1:
         raise ValueError("container must emit exactly one registration gate report")
     report = json.loads(lines[0])
+    validate_report(report, mode=mode)
+    return report
+
+
+def combine_reports(reports: list[dict], installer_sha256: str) -> dict:
+    if len(reports) != 2 or {report["mode"] for report in reports} != {"script", "wheel"}:
+        raise ValueError("both script and wheel registration stages must pass")
+    for report in reports:
+        validate_report(report, mode=report["mode"])
+    if reports[0]["versions"] != reports[1]["versions"]:
+        raise ValueError("registration stages used different agent CLI versions")
+    report = {
+        "ok": True, "mode": "all", "versions": reports[0]["versions"],
+        "cases": [row for stage in reports for row in stage["cases"]],
+        "image_ids": {stage["mode"]: stage["image_id"] for stage in reports},
+    }
+    for row in report["cases"]:
+        if row["scenario"] in SCRIPT_SCENARIOS and row.get("installer_sha256") != installer_sha256:
+            raise ValueError("script stage did not execute this checkout's install.sh")
     validate_report(report)
     return report
+
+
+def container_command(docker: str, name: str, image_id: str, mode: str) -> list[str]:
+    if mode not in {"script", "wheel"}:
+        raise ValueError(f"unknown registration mode: {mode}")
+    return [
+        docker, "run", "--rm", "--name", name,
+        "--network", "bridge" if mode == "script" else "none",
+        "--cap-drop", "ALL", "--security-opt", "no-new-privileges",
+        "--pids-limit", "256", image_id,
+    ]
 
 
 def run_logged(command: list[str], path: Path, timeout: int) -> subprocess.CompletedProcess:
@@ -58,23 +89,25 @@ def main(argv: list[str] | None = None) -> int:
         if info.stdout.strip() != "linux":
             raise RuntimeError("registration gates require a Linux Docker engine")
         with tempfile.TemporaryDirectory(prefix="agentic-hil-registration-") as temporary:
-            iidfile = Path(temporary) / "image-id"
-            print("Building the current working tree and locked agent CLIs...", flush=True)
-            run_logged([
-                docker, "build", "--target", "registration-gate", "--iidfile", str(iidfile),
-                "--file", "evals/install/container/Dockerfile", ".",
-            ], args.output / "build.log", 900)
-            image_id = iidfile.read_text().strip()
-            if not image_id.startswith("sha256:"):
-                raise RuntimeError("Docker did not produce an immutable image id")
-            print(f"Running all registration cases offline as an unprivileged user ({image_id})...", flush=True)
-            run_logged([
-                docker, "run", "--rm", "--name", name, "--network", "none",
-                "--cap-drop", "ALL", "--security-opt", "no-new-privileges",
-                "--pids-limit", "256", image_id,
-            ], args.output / "container.log", 900)
-            report = read_report((args.output / "container.log").read_text(encoding="utf-8"))
-            report["image_id"] = image_id
+            reports = []
+            installer_sha256 = hashlib.sha256((ROOT / "install.sh").read_bytes()).hexdigest()
+            for mode, target in (("script", "script-registration-gate"), ("wheel", "registration-gate")):
+                iidfile = Path(temporary) / f"{mode}-image-id"
+                print(f"Building the {mode} registration image and locked agent CLIs...", flush=True)
+                run_logged([
+                    docker, "build", "--target", target, "--iidfile", str(iidfile),
+                    "--file", "evals/install/container/Dockerfile", ".",
+                ], args.output / f"{mode}-build.log", 900)
+                image_id = iidfile.read_text().strip()
+                if not image_id.startswith("sha256:"):
+                    raise RuntimeError("Docker did not produce an immutable image id")
+                print(f"Running {mode} registration cases ({'downloads enabled' if mode == 'script' else 'offline'})...", flush=True)
+                log_path = args.output / f"{mode}-container.log"
+                run_logged(container_command(docker, name, image_id, mode), log_path, 900)
+                stage = read_report(log_path.read_text(encoding="utf-8"), mode=mode)
+                stage["image_id"] = image_id
+                reports.append(stage)
+            report = combine_reports(reports, installer_sha256)
             report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
             print(f"PASS: {len(report['cases'])} registration cases; {report['versions']}; report: {report_path}")
         return 0


### PR DESCRIPTION
## Summary

Run the real `install.sh` inside fresh Docker containers and fail CI unless it installs Agentic HIL and registers working MCP integrations for Codex and Claude Code. The harness checks the script's result directly; it does not repair registration with a separate `agent-install` or `setup` call.

## User-visible Change

- Add `python tools/test_agent_registration.py` and require its **Agent registration (Docker)** job in **Required CI**. Both stages are mandatory, for **20 cases total**.
- **Script stage, 4 cases:** start without Agentic HIL, uv, pipx or prepared wheels. Execute the checkout's unchanged `install.sh`, which bootstraps uv and downloads Agentic HIL with its default `[can]` extra from PyPI. Check explicit `--agent codex` / `--agent claude-code` and automatic detection for both clients. Record the installed version and require the executed script's SHA-256 to match the checkout.
- **Current-wheel stage, 16 cases:** install a wheel built from the current source offline. Check fresh/repeat installation, existing settings, setup, project refusal, invalid client configuration, operator conflicts and negative controls for missing registration and broken launchers.
- Both stages use the actual locked agent CLIs to check user-scope discovery in two projects, the registered launcher's MCP initialization, the complete applicable tool contract and a configuration tool call.
- Docker failures, download failures, timeouts, missing results, incomplete matrices and skipped cases fail the gate. Preserve the existing installation-evaluation image as the default Docker target and exclude repository-only gate tests from the source distribution.

## Validation

- [x] Combined Docker gate: **20/20 passed**; the four script cases downloaded and installed **Agentic HIL 0.21.5** during the run.
- [x] Real clients: Codex **0.145.0**, Claude Code **2.1.218**.
- [x] Focused pytest: **50 passed on Windows**, **30 passed on Linux**.
- [x] `ruff check src tests evals tools`, shipped-reference and version-consistency checks.
- [x] Wheel/sdist build and `twine check dist/*`; **3,680 tests collected** from the source distribution.
- [x] Tests and usage documentation updated.

The full pytest matrix is left to CI. Local results above cover the changed integration, runner and packaging.

## Hardware And Safety

All cases run as ordinary container users without host mounts or forwarded credentials. Docker builds and the script-installation stage have network access for public downloads; the current-wheel stage runs with `--network none`. Logs contain the installer's actual transcript. No model calls or agent logins are required.

## Platform Impact

Actual installation and CLI checks run in Linux Docker. The runner and report gates are also tested on Windows. The skill and tool contract are checked against the applicable package: the current-source wheel for development changes and the downloaded distribution for the published release.

## Hardware Validation

No physical hardware was used. Production hardware permissions and debugger interfaces are unchanged.

## Breaking Changes

No public CLI, MCP or configuration changes. CI gains a mandatory script-installation and registration check.
